### PR TITLE
HOTFIX: Rodentia have survival boxes now

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -18,7 +18,8 @@
     - Human
     - Moth
     - Reptilian
-    - Vulpkanin
+    - Vulpkanin # Box Change - Earlymerge Vulps
+    - Rodentia # Box Change - Adds Rodentia
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/rodentia.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McRat
-  parent: BaseMobSpecies # BoxStation change, changed from RMC custom entity
+  parent: BaseMobSpeciesOrganic # BoxStation change, changed from RMC custom entity # Hotfix: Change parent to the organic version. Hopefully fixes things. Rodentia might need a refactor.
   id: CMMobRodentia
   suffix: RMC14
   components:


### PR DESCRIPTION
## About the PR
Added Rodentia to the Oxygen Breather survival box group

## Why / Balance
They need that.

Also, made them parent of BaseMobSpeciesOrganic for now. I hope that fixes stuff but if it doesn't I hope it at least doesn't break stuff.

## Technical details

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Rodentia have survival boxes now
