### PR TITLE
tweak: Reduce IPC battery drain rate

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -78,7 +78,7 @@
   - type: Silicon
     entityType: enum.SiliconType.Player
     batteryPowered: true
-    drainPerSecond: 1.3 # DeltaV change from 1.5
+    drainPerSecond: 0.6 # DeltaV change from 1.5 # Box Change - 1.3 > 0.6
     chargeThresholdMid: 0.80
     chargeThresholdLow: 0.35
     chargeThresholdCritical: 0.10


### PR DESCRIPTION
## About the PR
Reduced IPC battery drain from 1.3 to 0.6

## Why / Balance
IPCs were ported from DeltaV.
DeltaV is configured to make all species hungry ~2.1x faster than WizDen/Harmony
Therefore, I have tweaked the drain rate of IPC batteries by ~2.1x

## Technical details

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: IPC battery drain rate has been reduced to be more on par with organic hunger speeds.
