### PR TITLE
Adds Scarfs And Pride Scarfs To Trinkets

### DIFF
--- a/Resources/Locale/en-US/_Box/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Box/preferences/loadout-groups.ftl
@@ -1,0 +1,2 @@
+loadout-group-scarfs = Scarfs
+loadout-group-pride-scarfs = Pride Scarfs

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -21,6 +21,27 @@
   - CigPackBlack
   - CigarCase
   - CigarGold
+  # Start Box Change - Scarf & Pride Scarf
+  - ClothingNeckScarfStripedRed
+  - ClothingNeckScarfStripedGreen
+  - ClothingNeckScarfStripedBlue
+  - ClothingNeckScarfStripedBlack
+  - ClothingNeckScarfStripedBrown
+  - ClothingNeckScarfStripedLightBlue
+  - ClothingNeckScarfStripedOrange
+  - ClothingNeckScarfStripedPurple
+  - ClothingNeckScarfStripedAce
+  - ClothingNeckScarfStripedAro
+  - ClothingNeckScarfStripedAroace
+  - ClothingNeckScarfStripedBiSexual
+  - ClothingNeckScarfStripedGay
+  - ClothingNeckScarfStripedInter
+  - ClothingNeckScarfStripedLesbian
+  - ClothingNeckScarfStripedPan
+  - ClothingNeckScarfStripedNonBinary
+  - ClothingNeckScarfStripedRainbow
+  - ClothingNeckScarfStripedTrans
+  # End Box Change - Scarf & Pride Scarf
   - ClothingNeckLGBTPin
   - ClothingNeckAllyPin
   - ClothingNeckAromanticPin

--- a/Resources/Prototypes/_Box/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Box/Loadouts/Miscellaneous/trinkets.yml
@@ -62,13 +62,6 @@
   groupBy: "PrideScarf"
 
 - type: loadout
-  id: ClothingNeckScarfStripedAce
-  storage:
-    back:
-    - ClothingNeckScarfStripedAce
-  groupBy: "PrideScarf"
-
-- type: loadout
   id: ClothingNeckScarfStripedAro
   storage:
     back:

--- a/Resources/Prototypes/_Box/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Box/Loadouts/Miscellaneous/trinkets.yml
@@ -1,0 +1,139 @@
+- type: loadout
+  id: ClothingNeckScarfStripedRed
+  storage:
+    back:
+    - ClothingNeckScarfStripedRed
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedGreen
+  storage:
+    back:
+    - ClothingNeckScarfStripedGreen
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedBlue
+  storage:
+    back:
+    - ClothingNeckScarfStripedBlue
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedBlack
+  storage:
+    back:
+    - ClothingNeckScarfStripedBlack
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedBrown
+  storage:
+    back:
+    - ClothingNeckScarfStripedBrown
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedLightBlue
+  storage:
+    back:
+    - ClothingNeckScarfStripedLightBlue
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedOrange
+  storage:
+    back:
+    - ClothingNeckScarfStripedOrange
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedPurple
+  storage:
+    back:
+    - ClothingNeckScarfStripedPurple
+  groupBy: "scarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedAce
+  storage:
+    back:
+    - ClothingNeckScarfStripedAce
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedAce
+  storage:
+    back:
+    - ClothingNeckScarfStripedAce
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedAro
+  storage:
+    back:
+    - ClothingNeckScarfStripedAro
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedAroace
+  storage:
+    back:
+    - ClothingNeckScarfStripedAroace
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedBiSexual
+  storage:
+    back:
+    - ClothingNeckScarfStripedBiSexual
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedGay
+  storage:
+    back:
+    - ClothingNeckScarfStripedGay
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedInter
+  storage:
+    back:
+    - ClothingNeckScarfStripedInter
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedLesbian
+  storage:
+    back:
+    - ClothingNeckScarfStripedLesbian
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedPan
+  storage:
+    back:
+    - ClothingNeckScarfStripedPan
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedNonBinary
+  storage:
+    back:
+    - ClothingNeckScarfStripedNonBinary
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedRainbow
+  storage:
+    back:
+    - ClothingNeckScarfStripedRainbow
+  groupBy: "PrideScarf"
+
+- type: loadout
+  id: ClothingNeckScarfStripedTrans
+  storage:
+    back:
+    - ClothingNeckScarfStripedTrans
+  groupBy: "PrideScarf"

--- a/Resources/Prototypes/_Box/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Box/Loadouts/loadout_groups.yml
@@ -11,7 +11,7 @@
   - ClothingNeckScarfStripedOrange
   - ClothingNeckScarfStripedPurple
 
-- Type: loadoutGroup
+- type: loadoutGroup
   id: PrideScarf
   name: loadout-group-pride-scarfs
   loadouts:

--- a/Resources/Prototypes/_Box/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Box/Loadouts/loadout_groups.yml
@@ -1,0 +1,28 @@
+- type: loadoutGroup
+  id: scarf
+  name: loadout-group-scarfs
+  loadouts:
+  - ClothingNeckScarfStripedRed
+  - ClothingNeckScarfStripedGreen
+  - ClothingNeckScarfStripedBlue
+  - ClothingNeckScarfStripedBlack
+  - ClothingNeckScarfStripedBrown
+  - ClothingNeckScarfStripedLightBlue
+  - ClothingNeckScarfStripedOrange
+  - ClothingNeckScarfStripedPurple
+
+- Type: loadoutGroup
+  id: PrideScarf
+  name: loadout-group-pride-scarfs
+  loadouts:
+  - ClothingNeckScarfStripedAce
+  - ClothingNeckScarfStripedAro
+  - ClothingNeckScarfStripedAroace
+  - ClothingNeckScarfStripedBiSexual
+  - ClothingNeckScarfStripedGay
+  - ClothingNeckScarfStripedInter
+  - ClothingNeckScarfStripedLesbian
+  - ClothingNeckScarfStripedPan
+  - ClothingNeckScarfStripedNonBinary
+  - ClothingNeckScarfStripedRainbow
+  - ClothingNeckScarfStripedTrans


### PR DESCRIPTION
## About the PR
This PR adds scarfs and pride scarfs to the trinket system, on request of someone on the discord.
https://discord.com/channels/1406523997306359848/1410486238888202240

## Why / Balance
- Scarfs can add extra customisation to a character (or act as a snack for moths i guess? but I dont think this is a game breaking balance decision).
- Not every station has a map pride vend, this can supplement that.


## Technical details
-creates Resources/Locale/en-US/_Box/preferences/loadout-groups.ftl to hold two strings to rename the trinket groups.
-modifies Resources/Prototypes/Loadouts/loadout_groups.yml to have all the appropriate prototypes added, all under a box comment block as appropriate to PR'ing standards.
-created the new scarf prototypes to be called by the above in Resources/Prototypes/_Box/Loadouts/Miscellaneous/trinkets.yml under box namespace.
-defined two new loadout groups in Resources/Prototypes/_Box/Loadouts/loadout_groups.yml under box namespace.

## Media
![mediaforpr](https://github.com/user-attachments/assets/bf490dba-89d6-45b5-9ada-d3a1654d9278)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- add: Adds scarfs to the trinkets menu.
- add: Adds pride scarfs to the trinkets menu.


