### PR TITLE
Removes the random character setting for the dev environment

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -39,6 +39,6 @@ preload_grids = false
 see_own_notes = true
 
 [ic]
-random_characters = true
+random_characters = false # Box Change - True > False - Gives devs control of who to bring into devenv
 random_species_weights = ""
 ssd_sleep_time = 3600


### PR DESCRIPTION
## About the PR
Turned off the setting that dictates that you must role a random character in the devenv

## Why / Balance
Its a negative for testing new species or species hotfixes.
(low priority pr)

## Technical details
Resources/ConfigPresets/Build/development.toml - set random_characters to false

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:

