### PR TITLE
HOTFIX: IPCs can now fall over again after being buckled

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
@@ -32,6 +32,7 @@
     - type: ZombieImmune
     - type: DoAfter
     - type: RotationVisuals
+      defaultRotation: 90 # Box Change
       horizontalRotation: 90
     - type: Examiner
     # - type: Recyclable


### PR DESCRIPTION
## About the PR
Fixed a bug where IPCs couldn't visually slip after being buckled

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
one line yaml change
Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml - gave the silicon base prototype a default rotation.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Fixed the bug preventing IPCs from visually falling over after they were buckled

