### PR TITLE
IPC Topical Remaster - Part 1 (Basic Topicals)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -14,8 +14,12 @@
       amount: !type:ConstantNumberSelector
         value: 2
     - id: Gauze
-    - id: MedkitIPCFilled # Box Change - Give Medbay starting supply of IPC Topicals
-    - id: IPCOilPack # Box Change - Give Medbay a stating supply of IPC Oil
+    # Box Change Start - IPC Topicals
+    - id: ChassisPatch
+    - id: CablePack
+    - id: RobotStructPack
+    - id: IPCOilPack
+    # Box Change End
 
 - type: entity
   parent: LockerMedicine

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -116,9 +116,9 @@
         Brute: -15 # 5 for each, like a bruise pack
       types:
         Cold: -1 # Structural Repair
-        Caustic: -1 # Structural Repair
+        # Caustic: -1 # Structural Repair # Box Change
     # bleedingModifier: -20 # DeltaV - IPCs bleed
-    bleedingModifier: -10 # Parity with Gauze
+    # bleedingModifier: -10 # Parity with Gauze # Box Change
 # Harmony Change Ends
 
 - type: entity

--- a/Resources/Prototypes/_Box/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/_Box/Catalog/Fills/Items/firstaidkits.yml
@@ -7,9 +7,9 @@
   - type: StorageFill
     contents:
     - id: ChassisPatch
-      amount: 2
     - id: CablePack
-    - id: WelderMini
+    - id: RobotStructPack
+    - id: IPCOilPack
 
 - type: entity
   parent: MedkitIPCAdvanced
@@ -19,7 +19,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: ChassisPatch
+    - id: IPCOilPack
     - id: ComponentPack
-    - id: RobotStructPack
+      amount: 2
     - id: ReplacementLenses

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
@@ -17,11 +17,11 @@
     # - Silicon # Harmony Change, as long as Borgs are immune to Radiation, trying to remove radiation damage from them crashes the game
     damage:
       groups:
-        Burn: -60 # 25 per type
-        Brute: -60 # 20 per type, mostly irrelevant cause welder gaming
+        Burn: -120 # Box Change - -60 > -120 - 30 per
+        Brute: -90 # Box Change - -60 > -90 - 30 per
       types:
-        Radiation: -20 # Harmony Change, IPC Omnizine
-    modifyBloodLevel: 25 # restores a lot of blood for IPCs.
+        Radiation: -30 # Harmony Change, IPC Omnizine # Box Change - -20 > -30
+    modifyBloodLevel: 45 # restores a lot of blood for IPCs. # Box Change - 25 > 45
     bloodlossModifier: -20 # DeltaV - IPCs bleed
   - type: Stack
     stackType: OmniPatch

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/healing.yml
@@ -16,7 +16,8 @@
     - HumanoidSilicon
     damage:
       types:
-        Heat: -0.5 # if this isn't here it doesn't work... might as well make it meaningful
+        Heat: -1 # if this isn't here it doesn't work... might as well make it meaningful # Box Change - -0.5 > -1
+        Blunt: -1 # Box Change
     modifyBloodLevel: 30 # restores a lot of blood for IPCs.
   - type: Stack
     stackType: IPCOilPack
@@ -53,8 +54,8 @@
     - HumanoidSilicon
     damage:
       types:
-        Heat: -5
-        Shock: -5
+        Heat: -10 # Box Change - -5 > -10
+        Shock: -10 # Box Change - -5 > -10
   - type: Stack
     stackType: CablePack
     count: 10
@@ -88,8 +89,8 @@
     - HumanoidSilicon
     damage:
       types:
-        Shock: -1
-        Radiation: -5
+        Shock: -10 # Box Change - -1 > -10
+        Radiation: -20 # Box Change - -5 > -20
   - type: Stack
     stackType: ComponentPack
     count: 10
@@ -125,9 +126,9 @@
     - HumanoidSilicon
     damage:
       groups:
-        Brute: -3 # Minor Brute repair, inverse of welding tool
+        Brute: -30 # Minor Brute repair, inverse of welding tool # Box Change - -3 > -30
       types:
-        Cold: -5
+        Cold: -10 # Box Change - -5 > -10
         Caustic: -5
   - type: Stack
     stackType: RobotStructPack
@@ -192,9 +193,10 @@
       - HumanoidSilicon
     damage:
       types:
-        Slash: -2.5
-        Piercing: -2.5
-    bloodlossModifier: -20
+        Slash: -5 # Box Change - -2.5 > -5
+        Piercing: -10 # Box Change -2.5 > -10
+        Blunt: -1 # Box Change
+    bloodlossModifier: -10 # Box Change - -20 > -10 - IPCs bleed differently
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
       params:

--- a/Resources/Prototypes/_Harmony/Recipes/Lathes/lathepacks.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Lathes/lathepacks.yml
@@ -88,10 +88,14 @@
   - ComponentPack
   - RobotStructPack
   - ReplacementLenses
-  - ChassisPatch
+  # - ChassisPatch # Box Change
 
 - type: latheRecipePack
   id: HarmonyIPCMedicalStatic # Allows these two to also be made in the MediFab
   recipes:
   - ReplacementLenses
   - ChassisPatch
+  # Box Change Start
+  - CablePack
+  - RobotStructPack
+  # Box Change End


### PR DESCRIPTION
## About the PR
Rebalanced and redistributed the basic IPC Topicals

## Why / Balance
<img width="1821" height="316" alt="image" src="https://github.com/user-attachments/assets/8c1a58d9-ae61-4ed1-aba8-73ed6088f5ad" />

Welders no longer stop bleeding, Structural Kits have been moved to the Basic category, and most topicals have received a buff to their healing power.

Medical can now consistenly find and make all basic topicals, meaning they should always be in a situation where they can repair IPCs.

Robotics can no longer make Chassis Patches. Their lathe is set up for flavour, and for when Borgs are migrated to the same repair system.

IPC Repair Kits no longer appear in the medical locker, instead their contents are simply inside it. The visual of a medkit spawning in the locker irked me, and it unintentionally made a Cargo Bounty easier.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="539" height="473" alt="image" src="https://github.com/user-attachments/assets/129ce58d-9f8b-4050-8cc3-5ab54a030d56" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: All IPC topicals have had their healing numbers improved
- tweak: Welders no longer stop an IPC from bleeding.

