### PR TITLE
Removes Extended Announcement

### DIFF
--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -94,21 +94,23 @@
     shoes: ClothingShoesBootsJack
     pocket1: MagazinePistol
     pocket2: MagazinePistol
-  inhand: 
+  inhand:
     - WeaponPistolMk58
 #  storage: # can't put starting gear in backpack. works for nukies, not for DM.
 #    back:
 #      - MagazinePistol
 #      - MagazinePistol
 
-- type: entity
-  parent: BaseStationEventShortDelay
-  id: ExtendedHarmonyAnnouncement
-  components:
-  - type: StationEvent
-    endAnnouncement: station-event-harmony-extended-announcement
-    maxOccurrences: 1
-    endAudio:
-      path: /Audio/Announcements/attention.ogg
-    duration: 1500 # 25 mins
-  - type: EmptyRule
+#Start Box Change - Comments out extended announcement rule
+#- type: entity
+#  parent: BaseStationEventShortDelay
+#  id: ExtendedHarmonyAnnouncement
+#  components:
+#  - type: StationEvent
+#    endAnnouncement: station-event-harmony-extended-announcement
+#    maxOccurrences: 1
+#    endAudio:
+#      path: /Audio/Announcements/attention.ogg
+#    duration: 1500 # 25 mins
+#  - type: EmptyRule
+#End Box Change - comments out extended announcement rule

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -83,7 +83,7 @@
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  - ExtendedHarmonyAnnouncement # harmony
+ #- ExtendedHarmonyAnnouncement # harmony - Box Change, comments out extended announcement.
 
 - type: gamePreset
   id: Greenshift


### PR DESCRIPTION
## About the PR
This PR comments out the code that makes the extended announcement run on Extended.

## Why / Balance
We're almost always going to be on extended due to running custom antags + admin events. Having an announcement pop up saying we're in a low-threat sector when a Syndicate agent is actively in the middle of shooting someone is a jarring tonal shift that we can do without.

## Technical details
-Comments out code in Resources/Prototypes/_Harmony/GameRules/roundstart.yml
-Comments out a gamerule in Resources/Prototypes/game_presets.yml

## Media
<img width="599" height="407" alt="Untitled" src="https://github.com/user-attachments/assets/f8e086a1-27bc-42de-a961-9a13e5e5ef77" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- remove: the extended announcement has been removed, as it is not fit for purpose.

