### PR TITLE
IPC Blood Works for Artifact Nodes

### DIFF
--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -243,6 +243,7 @@
     - AmmoniaBlood
     - ZombieBlood
     - Sap
+    - IPCOil #Box Change - IPC blood can be used for artifacts
 
 - type: xenoArchTrigger
   id: TriggerThrow


### PR DESCRIPTION
## About the PR
What it says on the tin. IPC blood (IPCOil) now works for the blood xenoarcheology node.

## Why / Balance
- not much to say. IPCs can now work xenoarch easier without having to find a willing (or unwilling) donor.

## Technical details
- adds IPCOil as a valid reagent in Resources/Prototypes/XenoArch/triggers.yml, and comments appropriately as a box change.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: IPC blood now works for blood xenoarcheology nodes.