### PR TITLE
Updates IPC resistances

### DIFF
--- a/Resources/Prototypes/_EE/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EE/Damage/modifier_sets.yml
@@ -1,8 +1,13 @@
 - type: damageModifierSet
   id: IPC
   coefficients:
+    # Box Change Start - Added Brute resist
+    Blunt: 0.85
+    Slash: 0.85
+    Piercing: 0.9
+    # Box Change End
     Poison: 0
     # Cold: 0.5 # Harmony Change, Comments out Cold Resistance
-    Heat: 1.5
+    Heat: 1.3 # Box Change - 1.5 > 1.3
     Shock: 2.0
     Radiation: 0.5 # DeltaV - was not real

--- a/Resources/ServerInfo/_Box/Guidebook/Mobs/IPCs.xml
+++ b/Resources/ServerInfo/_Box/Guidebook/Mobs/IPCs.xml
@@ -3,7 +3,7 @@
   <GuideEntityEmbed Entity="MobIPCDummy" Caption="I.P.C."/>
   An IPC (short for Integrated Positronic Chassis) is a type of sentient robot and is considered an [color=yellow]independent individual[/color], meaning [color=red]they are not guided by any laws of robotics[/color]. IPCs cannot be hacked by Emags because they do not have to follow any predefined directives in their system. [color=red]IPCs are silicon-based beings, so they are healed differently to organic species.[/color]
 
-  They take [color=#1e90ff]15% less Blunt and Slash, 10% less Piercing, and 50% less Radiation damage[/color] but [color=#ffa500]30% more Heat damage, and 100% more Shock Damage.[/color] As they are Inorganic, they do not take Poison, Asphyxiation, Bloodloss, or Genetic damage, and have unique wasy to metabolize Reagents.
+  They take [color=#1e90ff]15% less Blunt and Slash, 10% less Piercing, and 50% less Radiation damage[/color] but [color=#ffa500]30% more Heat damage, and 100% more Shock Damage.[/color] As they are Inorganic, they do not take Poison, Asphyxiation, Bloodloss, or Genetic damage, and have unique ways to metabolize Reagents.
 
   An IPC's punch deals 6 blunt damage.
 

--- a/Resources/ServerInfo/_Box/Guidebook/Mobs/IPCs.xml
+++ b/Resources/ServerInfo/_Box/Guidebook/Mobs/IPCs.xml
@@ -3,7 +3,7 @@
   <GuideEntityEmbed Entity="MobIPCDummy" Caption="I.P.C."/>
   An IPC (short for Integrated Positronic Chassis) is a type of sentient robot and is considered an [color=yellow]independent individual[/color], meaning [color=red]they are not guided by any laws of robotics[/color]. IPCs cannot be hacked by Emags because they do not have to follow any predefined directives in their system. [color=red]IPCs are silicon-based beings, so they are healed differently to organic species.[/color]
 
-  They take [color=#1e90ff]50% less Radiation damage[/color] but [color=#ffa500]50% more Heat damage, and 100% more Shock Damage.[/color] As they are Inorganic, they do not take Poison, Asphyxiation, Bloodloss, or Genetic damage, and Cannot Metabolize Reagents.
+  They take [color=#1e90ff]15% less Blunt and Slash, 10% less Piercing, and 50% less Radiation damage[/color] but [color=#ffa500]30% more Heat damage, and 100% more Shock Damage.[/color] As they are Inorganic, they do not take Poison, Asphyxiation, Bloodloss, or Genetic damage, and have unique wasy to metabolize Reagents.
 
   An IPC's punch deals 6 blunt damage.
 


### PR DESCRIPTION
## About the PR
IPCs now have minor brute resistances (15% Blunt and Slash, 10% pierce) and their heat weakness was toned down (50%>30%).

## Why / Balance
As the HoS has a special heat gun that packs a real punch, the existing heat weakness was overtuned. 
The energy magnun downed in 2.66 shots, whereas now it downs in 3.07.

They also gained a minor brute resist, as they are made of metal. When playing it felt strange that space carp could bite through solid steel as well as they could through flesh.

Overall, IPCs are very reliant on do-after based healing, do not naturally regenerate blood, and are hard-countered by stuns. As our IPCs do not have as many benefits as other forks to counteract these, I felt modifying their resistances was worthwile.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="665" height="436" alt="image" src="https://github.com/user-attachments/assets/7b372d30-4b85-436b-ac1e-b1398da13aa7" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
🆑 
- tweak: IPCs damage weaknesses and resistances have been tweaked.

