### PR TITLE
More IPC Chems

### DIFF
--- a/Resources/Locale/en-US/_Box/reagents/meta/fun_synthetic.ftl
+++ b/Resources/Locale/en-US/_Box/reagents/meta/fun_synthetic.ftl
@@ -6,3 +6,6 @@ reagent-desc-bitflipper = A suspension of nanites that chaotically interfere wit
 
 reagent-name-surge = surge
 reagent-desc-surge = A sketchy superconducting gel that overloads processors, causing an effect reportedly similar to opiates in synthetic units.
+
+reagent-name-mechazine = mechazine
+reagent-desc-mechazine = A collaboration between Donk Co. and S.E.L.F. that allows synthetic agents to use all the effects of Surge but without most of the downsides, and even repairs them in dire circumstances.

--- a/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
+++ b/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
@@ -24,3 +24,6 @@ reagent-desc-degreaser = An industrial degreaser which can be used to clean resi
 
 reagent-name-routine-maintenance = routine maintenance
 reagent-desc-routine-maintenance = A general purpose repairing nantie suspension capable of handling most low-impact damages to synthetic lifeforms.
+
+reagent-name-nanoweldite = nanoweldite
+reagent-desc-nanoweldite = A nanite suspension equiped with hyper-efficient nanowelders. It's not good at telling when it is and isn't inside a synthetic lifeform.

--- a/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
+++ b/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
@@ -23,13 +23,13 @@ reagent-name-degreaser = degreaser
 reagent-desc-degreaser = An industrial degreaser which can be used to clean residual build-up from machinery and surfaces.
 
 reagent-name-routine-maintenance = routine maintenance
-reagent-desc-routine-maintenance = A general purpose repairing nantie suspension capable of handling most low-impact damages to synthetic lifeforms.
+reagent-desc-routine-maintenance = A general purpose repairing nanite suspension capable of handling most low-impact damages to synthetic lifeforms.
 
 reagent-name-nanoweldite = nanoweldite
-reagent-desc-nanoweldite = A nanite suspension equiped with hyper-efficient nanowelders. It's not good at telling when it is and isn't inside a synthetic lifeform.
+reagent-desc-nanoweldite = A nanite suspension equiped with hyper-efficient nanowelders. It can't tell the difference between organics and synthetics.
 
 reagent-name-soi-sapphire = SOI sapphire
-reagent-desc-soi-sapphire = Deposits a protective layer of Sapphire on vital components in synthetic lifeforms, reducing the effects of radiation by 90%. Not recommended for use by organics.
+reagent-desc-soi-sapphire = Deposits a temporary protective layer of sapphire on vital components in synthetic lifeforms, reducing the effects of radiation by 90%. Not recommended for use by organics.
 
 reagent-name-ecc-memory = ECC memory
 reagent-desc-ecc-memory = A nanite program capable of detecting and correcting n-bit errors caused by radiation.

--- a/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
+++ b/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
@@ -27,3 +27,12 @@ reagent-desc-routine-maintenance = A general purpose repairing nantie suspension
 
 reagent-name-nanoweldite = nanoweldite
 reagent-desc-nanoweldite = A nanite suspension equiped with hyper-efficient nanowelders. It's not good at telling when it is and isn't inside a synthetic lifeform.
+
+reagent-name-soi-sapphire = SOI sapphire
+reagent-desc-soi-sapphire = Deposits a protective layer of Sapphire on vital components in synthetic lifeforms, reducing the effects of radiation by 90%. Not recommended for use by organics.
+
+reagent-name-ecc-memory = ECC memory
+reagent-desc-ecc-memory = A nanite program capable of detecting and correcting n-bit errors caused by radiation.
+
+reagent-name-thermal-paste = thermal paste
+reagent-desc-thermal-paste = A thermal paste specifically engineered for synthetic lifeforms, capable of returning them to operational temperatures.

--- a/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
+++ b/Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
@@ -21,3 +21,6 @@ reagent-desc-liquid-solder = A solution formulated to clean and repair damaged c
 
 reagent-name-degreaser = degreaser
 reagent-desc-degreaser = An industrial degreaser which can be used to clean residual build-up from machinery and surfaces.
+
+reagent-name-routine-maintenance = routine maintenance
+reagent-desc-routine-maintenance = A general purpose repairing nantie suspension capable of handling most low-impact damages to synthetic lifeforms.

--- a/Resources/Prototypes/_Box/Reagents/fun_synthetic.yml
+++ b/Resources/Prototypes/_Box/Reagents/fun_synthetic.yml
@@ -109,3 +109,56 @@
         component: StaminaModifier
         time: 3
         type: Add
+
+# Mechazine - Surge+
+- type: reagent
+  id: Mechazine
+  name: reagent-name-mechazine
+  group: Narcotics
+  desc: reagent-desc-mechazine
+  physicalDesc: reagent-physical-desc-energizing
+  flavor: shocking
+  color: "#C7BC1C"
+  metabolisms:
+    Malware:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+        damage:
+          types:
+            Shock: 2
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.1
+        sprintSpeedModifier: 1.1
+      - !type:Jitter
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: StaminaModifier
+        component: StaminaModifier
+        time: 3
+        type: Add
+    Software:
+      metabolismRate: 1.0
+      effects:
+      - !type:ResetNarcolepsy
+      - !type:HealthChange
+        conditions:
+        - !type:TotalDamage
+          min: 80 # only heals when you're more dead than alive
+        damage:
+          types: # No Shock No Rad
+            Blunt: -0.2
+            Slash: -0.2
+            Piercing: -0.2
+            Heat: -0.2
+            Cold: -0.2
+            Caustic: -0.2

--- a/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
@@ -252,3 +252,52 @@
             Heat: -0.15
             Shock: -0.15
             Cold: -0.15
+
+# Nanoweldite - Discount Omni for brutes, hard but possible to make
+- type: reagent
+  id: Nanoweldite
+  name: reagent-name-nanoweldite
+  parent: BasePyrotechnic
+  group: Medicine
+  desc: reagent-desc-nanoweldite
+  physicalDesc: reagent-physical-desc-metallic
+  flavor: metallic
+  color: "#B18E7D"
+  tileReactions:
+  - !type:FlammableTileReaction {}
+  metabolisms:
+    Industrial:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Slash: -2
+            Piercing: -2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 11.5
+        damage:
+          types:
+            Heat: 1
+    Poison:
+      effects:
+      - !type:SatiateThirst
+        factor: 0.5
+        conditions:
+        - !type:OrganType
+          type: Vox
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: false
+        damage:
+          types:
+            Poison: 0.5
+      - !type:HealthChange
+        damage:
+          types:
+            Heat: 0.5
+      - !type:FlammableReaction
+        multiplier: 0.4

--- a/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
@@ -301,3 +301,108 @@
             Heat: 0.5
       - !type:FlammableReaction
         multiplier: 0.4
+
+# SOI Sapphire - Radiation Protection ("Silicon on Insulator Sapphire", used to shield components from radiation)
+- type: reagent
+  id: SOISapphire
+  name: reagent-name-soi-sapphire
+  group: Medicine
+  desc: reagent-desc-soi-sapphire
+  physicalDesc: reagent-physical-desc-shiny
+  flavor: metallic
+  color: "#0f52ba"
+  metabolisms:
+    Industrial:
+      effects:
+      - !type:GenericStatusEffect
+        key: RadiationProtection
+        component: RadiationProtection
+        time: 2
+        type: Add
+        refresh: false
+      - !type:HealthChange
+        conditions:
+          - !type:ReagentThreshold
+            min: 20
+        damage:
+          types:
+            Shock: 1
+    Poison:
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Poison: 0.1
+              Slash: 0.1 # Getting sapphire deposited inside you will probably cut you up
+
+# ECC Memory - Anti-Rads med for IPCs, trades rads for minor shock, 3:1 ratio. - "Error correction code memory"
+- type: reagent
+  id: ECCMemory
+  name: reagent-name-ecc-memory
+  group: Medicine
+  desc: reagent-desc-ecc-memory
+  physicalDesc: reagent-physical-desc-reasonably-metallic
+  flavor: tingly
+  color: "#824F41"
+  metabolisms:
+    Software:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Radiation: -3
+            Shock: 1 # Less overall damage than Arith, but organics can heal up minor arith damage
+
+# Thermal Paste - Temp Stabilizer
+- type: reagent
+  id: ThermalPaste
+  name: reagent-name-thermal-paste
+  group: Medicine
+  desc: reagent-desc-thermal-paste
+  physicalDesc: reagent-physical-desc-thick-and-grainy
+  flavor: bitter
+  color: "#9CA2C6"
+  metabolisms:
+    Industrial:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Cold: -0.05
+            Heat: -0.05
+      - !type:AdjustTemperature
+        conditions:
+        - !type:Temperature
+          max: 293.15
+        amount: 100000 # thermal energy, not temperature!
+      - !type:AdjustTemperature
+        conditions:
+        - !type:Temperature
+          min: 293.15
+        amount: -10000
+      - !type:PopupMessage
+        type: Local
+        visualType: Medium
+        messages: [ "leporazine-effect-temperature-adjusting" ]
+        probability: 0.2
+    Poison:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: false
+        damage:
+          types:
+            Poison: 0.5
+      - !type:ChemVomit
+        conditions:
+        - !type:OrganType
+          type: Vox
+          shouldHave: false
+        probability: 0.02
+      - !type:SatiateHunger
+        factor: 1
+        conditions:
+        - !type:OrganType
+          type: Vox

--- a/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
@@ -228,3 +228,27 @@
       - !type:AdjustReagent
         reagent: SpaceLube
         amount: -3.0
+
+# Routine Maintenance - RoboTrico
+- type: reagent
+  id: RoutineMaintenance
+  name: reagent-name-routine-maintenance
+  group: Medicine
+  desc: reagent-desc-routine-maintenance
+  physicalDesc: reagent-physical-desc-metallic
+  flavor: metallic
+  color: "#c9d4db"
+  metabolisms:
+    Software:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:TotalDamage
+          max: 60
+        damage:
+          groups:
+            Brute: -0.45
+          types:
+            Heat: -0.15
+            Shock: -0.15
+            Cold: -0.15

--- a/Resources/Prototypes/_Box/Recipes/Reactions/fun_synthetic.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/fun_synthetic.yml
@@ -40,3 +40,14 @@
       amount: 1
   products:
     Surge: 4
+
+- type: reaction
+  id: Mechazine
+  minTemp: 300
+  reactants:
+    Surge:
+      amount: 1
+    Vestine:
+      amount: 1
+  products:
+    Mechazine: 1

--- a/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
@@ -114,3 +114,21 @@
       amount: 1
   products:
     RoutineMaintenance: 4
+
+- type: reaction
+  id: Nanoweldite
+  reactants:
+    Phosphorus:
+      amount: 3
+    Sulfur:
+      amount: 2
+    Oxygen:
+      amount: 2
+    Plasma:
+      amount: 1
+    WeldingFuel:
+      amount: 1
+    ActivatedSilicon:
+      amount: 1
+  products:
+    Nanoweldite: 5

--- a/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
@@ -102,3 +102,15 @@
   products:
     ComputerCoolant: 1
     IndustrialLubricant: 1
+
+- type: reaction
+  id: RoutineMaintenance
+  reactants:
+    ActivatedSilicon:
+      amount: 1
+    Iron:
+      amount: 3
+    Aluminium:
+      amount: 1
+  products:
+    RoutineMaintenance: 4

--- a/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
@@ -117,15 +117,16 @@
 
 - type: reaction
   id: Nanoweldite
+  minTemp: 420
+  maxTemp: 520 # Hot Enough it can coagulate and form, but not too hot that it ignites instead
+  priority: 20
   reactants:
     Phosphorus:
       amount: 3
     Sulfur:
       amount: 2
-    Oxygen:
-      amount: 2
     Plasma:
-      amount: 1
+      amount: 3
     WeldingFuel:
       amount: 1
     ActivatedSilicon:

--- a/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
@@ -132,3 +132,38 @@
       amount: 1
   products:
     Nanoweldite: 5
+
+- type: reaction
+  id: SOISapphire
+  minTemp: 300
+  reactants:
+    ActivatedSilicon:
+      amount: 1
+    Aluminium:
+      amount: 2
+    Oxygen:
+      amount: 3
+  products:
+    SOISapphire: 5
+
+- type: reaction
+  id: ECCMemory
+  reactants:
+    SOISapphire:
+      amount: 1
+    Radium:
+      amount: 1
+    Iodine:
+      amount: 2
+  products:
+    ECCMemory: 4
+
+- type: reaction
+  id: ThermalPaste
+  reactants:
+    Leporazine:
+      amount: 1
+    SOISapphire:
+      amount: 3
+  products:
+    ThermalPaste: 4


### PR DESCRIPTION
## About the PR
Adds five new IPC Chemicals: Thermal Paste, Routine Maintenance, ECC Memory, SOI Sapphire, Nanoweldite, and Mechazine.

## Why / Balance
While the initial batch of IPC chems allow for interesting gameplay, there was a distinct lack of chems that would be reasonable and useful for a Chemist to make for the Medbay.
Also, while a large portion of the original chems were antag-focused, the niche of "very useful when taken by the antag" was still underdeveloped.
<details>
<summary>The new chems are as follows:</summary>

### Mechazine
Made from Surge and Vestine, acts as the synthetic equivalent for Hyperzine and is intended for later use as an uplink chemical

### Routine Maintenance
An easily accessible, general purpose chem that is well suited for low-level injuries.
Made with Activated Silicon, Iron, and Aluminium

### Nanoweldite
An expensive chem with potent healing effects for Slash and Piercing. Good for chemists who have finished most of their work and want a challenge.

### SOI Sapphire
Used as an ingredient for Thermal Paste and ECC Memory, and also provides temporary Rad Resistance.

### ECC Memory
As it stands, Radiation is the hardest standard damage type to treat. This was somewhat intentional, but it has been to a far too high degree. This chem aims to rectify that without invalidating the other options available.

### Thermal Paste
The initial chems for IPCs included cryogenic chemicals, but did not include any way to stabilize an IPCs temperature. 
Thermal Paste stabilizes an IPCs temperature, and has very minor healing effects for temperature-based damage.

</details>

## Technical details
Adds Mechazine:
- Resources/Locale/en-US/_Box/reagents/meta/fun_synthetic.ftl
- Resources/Prototypes/_Box/Reagents/fun_synthetic.yml
- Resources/Prototypes/_Box/Recipes/Reactions/fun_synthetic.yml

Adds the other four chems
- Resources/Locale/en-US/_Box/reagents/meta/medicine_synthetic.ftl
- Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
- Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml

## Media
<img width="650" height="506" alt="image" src="https://github.com/user-attachments/assets/d1110111-df1d-423d-a172-309d0d3d5493" />

<img width="654" height="321" alt="image" src="https://github.com/user-attachments/assets/58282c07-b90e-41a9-a169-bf8216c6c32f" />

<img width="653" height="592" alt="image" src="https://github.com/user-attachments/assets/5aae39d1-4a2d-440c-956d-d0537f390edd" />

<img width="651" height="389" alt="image" src="https://github.com/user-attachments/assets/f4426785-f4e3-4893-a107-748f1272d97b" />

<img width="656" height="295" alt="image" src="https://github.com/user-attachments/assets/f200a4c9-08a4-4418-8bd6-7b1cf73618d5" />

<img width="649" height="508" alt="image" src="https://github.com/user-attachments/assets/a1cf1512-0b41-47fd-adf7-6fdecad46e5c" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Adds Mechazine, a better Surge that is made with Vestine
- add: Adds Routine Maintenance, an IPC Chem easily creatable by chemistry with limited healing properties
- add: Adds Nanoweldite, an IPC Chem with potent healing properties
- add: Adds SOI Sapphire, an IPC Chem that gives Radiation resistance
- add: Adds ECC Memory, an IPC Chem for treading Radiation damage
- add: Adds Thermal Paste, an IPC Chem capable of stabilizing temperature

