### PR TITLE
Sleeper Agents Begone!

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -45,7 +45,7 @@
     - id: DragonSpawn
     - id: NinjaSpawn
     - id: ParadoxCloneSpawn
-    - id: SleeperAgents
+    #    - id: SleeperAgents - Box Change, Comments out Sleeper Agent
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     # - id: WizardSpawn - Harmony Change, disables wizard midround


### PR DESCRIPTION
## About the PR
Comments out sleepers in the event table to prevent them running naturally.
Means admins have more control.
## Why / Balance
Gives admins more control over the event scheduler.

## Technical details
- comments out a line in Resources/Prototypes/GameRules/events.yml

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
Not player facing. No comment needed.
