### PR TITLE
Modifies the balance of SynthChem recipes

### DIFF
--- a/Resources/Prototypes/_Box/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/chemicals.yml
@@ -45,6 +45,8 @@
 
 - type: reaction
   id: CarbonMonoxide
+  requiredMixerCategories:
+  - Stir
   minTemp: 570
   reactants:
     Carbon:

--- a/Resources/Prototypes/_Box/Recipes/Reactions/chemicals_synthetic.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/chemicals_synthetic.yml
@@ -14,10 +14,27 @@
     ActivatedSilicon: 9
 
 - type: reaction
+  id: ActivatedSiliconDuplication
+  requiredMixerCategories:
+  - Stir
+  minTemp: 500
+  reactants:
+    ActivatedSilicon:
+      amount: 1
+    Silicon:
+      amount: 1
+    Plasma:
+      amount: 1
+      catalyst: true
+  products:
+    ActivatedSilicon: 2
+
+- type: reaction
   id: Synthanol
   reactants:
     Plasma:
       amount: 1
+      catalyst: true
     Ethanol:
       amount: 1
   products:

--- a/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Recipes/Reactions/medicine_synthetic.yml
@@ -8,7 +8,7 @@
     Arithrazine:
       amount: 1
   products:
-    EmergencyDefragmenter: 1
+    EmergencyDefragmenter: 2
 
 - type: reaction
   id: CryostabilizedDefragmenter
@@ -53,7 +53,7 @@
     Epinephrine:
       amount: 1
   products:
-    Recal: 1
+    Recal: 3
 
 - type: reaction
   id: LiquidSolder
@@ -65,7 +65,7 @@
     Aluminium:
       amount: 1
   products:
-    LiquidSolder: 1
+    LiquidSolder: 3
 
 - type: reaction
   id: Degreaser
@@ -75,7 +75,7 @@
     Ethylredoxrazine:
       amount: 1
   products:
-    Degreaser: 1
+    Degreaser: 2
 
 # Recipe for Omni > IPC Omni - deactivate if OP *or* unused
 - type: reaction
@@ -84,7 +84,7 @@
     Omnizine:
       amount: 4
     ActivatedSilicon:
-      amount: 4
+      amount: 2
     Plasma:
       amount: 2
   products:
@@ -145,7 +145,7 @@
     Oxygen:
       amount: 3
   products:
-    SOISapphire: 5
+    SOISapphire: 6
 
 - type: reaction
   id: ECCMemory

--- a/Resources/Prototypes/_Harmony/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Reactions/chemicals.yml
@@ -16,7 +16,7 @@
     Water:
       amount: 3
   products:
-    ComputerCoolant: 2
+    ComputerCoolant: 3
 
 - type: reaction
   id: EthyleneGlycol


### PR DESCRIPTION
## About the PR
Patches out a bug affecting Inap and Sodium Carbonate
Tweaks the output of a handful of SyntChem reagents

## Why / Balance
While SynthChem was intended to have restrictive outputs, it was overdone.
Also, the addition of Carbon Monoxide resulted in an unintended barrier for making Inap (needed for Bic) and Sodium Carbonate (needed for Sigy).

Also adds a way to 'duplicate' Activated Silicon, as the initial recipe is intense for how much is needed.

## Technical details

## Media

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**
:cl:
- fix: You can no longer accidentally make Carbon Monoxide when intending to make Inaprovaline or Sodium Carbonate
- tweak: Carbon Monoxide now requires stirring to make
- tweak: Recal, Degreaser, SOI Sapphire, Emergency Defragmentor, Liquid Solder, and Computer Coolant have had their output increased
- tweak: The recipe for Synthanol no longer consumes Plasma
- tweak: Smart Metal now needs less Activated Silicon
- add: An alternate recipe for Activated Silicon has been added, allowing you to convert silicon into it directly if you already have some.

