### PR TITLE
Revert upstream #41174, borg panel opens with Screwing

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -112,7 +112,7 @@
       - BorgChassis
       - RoboticsConsole
   - type: WiresPanel
-    openingTool: Prying
+    openingTool: Screwing
   - type: ActivatableUIRequiresPanel
   - type: NameIdentifier
     group: Silicon

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -112,7 +112,7 @@
       - BorgChassis
       - RoboticsConsole
   - type: WiresPanel
-    openingTool: Screwing
+    openingTool: Screwing # BoxStation - reverts panel from Prying to Screwing
   - type: ActivatableUIRequiresPanel
   - type: NameIdentifier
     group: Silicon


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
Reverts upstream [#41174](https://github.com/space-wizards/space-station-14/pull/41174). Borg panels now open with Screwing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a confusing change to revert, considering most players ended up getting used to Screwing for borg panels, and it keeps parity with every other panel in the game.

## Technical details
<!-- Summary of code changes for easier review. -->
Changes `Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml.` 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reverts borg panels from Prying to Screwing.
