### PR TITLE
IPCs no longer sleep when they run out of battery

### DIFF
--- a/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
+++ b/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
@@ -6,6 +6,7 @@ using Content.Server._EE.Power.Components;
 using Content.Server.Humanoid;
 using Content.Shared.Humanoid;
 using Content.Shared.StatusEffectNew; // starcup
+using Content.Shared.Stunnable; // Box Change - IPC No Battery Refactor
 
 namespace Content.Server._EE.Silicon.Death;
 
@@ -15,12 +16,15 @@ public sealed class SiliconDeathSystem : EntitySystem
     [Dependency] private readonly SiliconChargeSystem _silicon = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearanceSystem = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffect = default!; // starcup
+    [Dependency] private readonly SharedStunSystem _stun = default!; // Box Change - IPC No Battery Refactor
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<SiliconDownOnDeadComponent, SiliconChargeStateUpdateEvent>(OnSiliconChargeStateUpdate);
+
+        SubscribeLocalEvent<SiliconDownOnDeadComponent, StandUpAttemptEvent>(OnStandUpAttempt); // Box Change - IPC No Battery Refactor
     }
 
     private void OnSiliconChargeStateUpdate(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, SiliconChargeStateUpdateEvent args)
@@ -48,8 +52,10 @@ public sealed class SiliconDeathSystem : EntitySystem
         if (deadEvent.Cancelled)
             return;
 
-        EntityManager.EnsureComponent<SleepingComponent>(uid);
-        _statusEffect.TrySetStatusEffectDuration(uid, SleepingSystem.StatusEffectForcedSleeping); // starcup: edited for status effects refactor
+        // Box Change Start - IPC No Battery Refactor
+        // EntityManager.EnsureComponent<SleepingComponent>(uid);
+        // _statusEffect.TrySetStatusEffectDuration(uid, SleepingSystem.StatusEffectForcedSleeping); // starcup: edited for status effects refactor
+        // Box Change End
 
         if (TryComp(uid, out HumanoidAppearanceComponent? humanoidAppearanceComponent))
         {
@@ -59,18 +65,32 @@ public sealed class SiliconDeathSystem : EntitySystem
 
         siliconDeadComp.Dead = true;
 
+        EnsureComp<KnockedDownComponent>(uid); // Box Change - IPC No Battery Refactor
+
         RaiseLocalEvent(uid, new SiliconChargeDeathEvent(uid, batteryComp, batteryUid));
     }
 
     private void SiliconUnDead(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, BatteryComponent? batteryComp, EntityUid batteryUid)
     {
-        _statusEffect.TryRemoveStatusEffect(uid, SleepingSystem.StatusEffectForcedSleeping); // starcup: edited for status effects refactor
-        _sleep.TryWaking(uid, true, null);
+        // Box Change Start - IPC No Battery Refactor
+        // _statusEffect.TryRemoveStatusEffect(uid, SleepingSystem.StatusEffectForcedSleeping); // starcup: edited for status effects refactor
+        // _sleep.TryWaking(uid, true, null);
+        // Box Change End
 
         siliconDeadComp.Dead = false;
 
+        _stun.TryStanding(uid); // Box Change - IPC No Battery Refactor
+
         RaiseLocalEvent(uid, new SiliconChargeAliveEvent(uid, batteryComp, batteryUid));
     }
+
+    // Box Change Start - Alt Low Battery System
+    private void OnStandUpAttempt(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, ref StandUpAttemptEvent args)
+    {
+        if (siliconDeadComp.Dead)
+            args.Cancelled = true;
+    }
+    // Box Change End
 }
 
 /// <summary>

--- a/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
+++ b/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
@@ -6,7 +6,16 @@ using Content.Server._EE.Power.Components;
 using Content.Server.Humanoid;
 using Content.Shared.Humanoid;
 using Content.Shared.StatusEffectNew; // starcup
-using Content.Shared.Stunnable; // Box Change - IPC No Battery Refactor
+ // Box Change Start - IPC No Battery Refactor
+using Content.Shared.Stunnable;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Puppet;
+using Content.Shared.Speech;
+using Content.Shared.Speech.Muting;
+using Content.Shared._Harmony.Speech.Hypophonia;
+using Content.Server.Popups;
+// Box Change End
 
 namespace Content.Server._EE.Silicon.Death;
 
@@ -16,7 +25,10 @@ public sealed class SiliconDeathSystem : EntitySystem
     [Dependency] private readonly SiliconChargeSystem _silicon = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearanceSystem = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffect = default!; // starcup
-    [Dependency] private readonly SharedStunSystem _stun = default!; // Box Change - IPC No Battery Refactor
+    // Box Change Start - IPC No Battery Refactor
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    // Box Change End
 
     public override void Initialize()
     {
@@ -24,7 +36,12 @@ public sealed class SiliconDeathSystem : EntitySystem
 
         SubscribeLocalEvent<SiliconDownOnDeadComponent, SiliconChargeStateUpdateEvent>(OnSiliconChargeStateUpdate);
 
-        SubscribeLocalEvent<SiliconDownOnDeadComponent, StandUpAttemptEvent>(OnStandUpAttempt); // Box Change - IPC No Battery Refactor
+    // Box Change Start - IPC No Battery Refactor
+        SubscribeLocalEvent<SiliconDownOnDeadComponent, StandUpAttemptEvent>(OnStandUpAttempt);
+        SubscribeLocalEvent<SiliconDownOnDeadComponent, AttackAttemptEvent>(OnAttackAttempt);
+        // SubscribeLocalEvent<SiliconDownOnDeadComponent, ShotAttemptedEvent>(OnShootAttempt);
+        SubscribeLocalEvent<SiliconDownOnDeadComponent, SpeakAttemptEvent>(OnSpeakAttempt);
+    // Box Change End
     }
 
     private void OnSiliconChargeStateUpdate(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, SiliconChargeStateUpdateEvent args)
@@ -84,13 +101,62 @@ public sealed class SiliconDeathSystem : EntitySystem
         RaiseLocalEvent(uid, new SiliconChargeAliveEvent(uid, batteryComp, batteryUid));
     }
 
-    // Box Change Start - Alt Low Battery System
+// Box Change Start - Alt Low Battery System
+    // Disallow Standing
     private void OnStandUpAttempt(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, ref StandUpAttemptEvent args)
     {
         if (siliconDeadComp.Dead)
             args.Cancelled = true;
     }
-    // Box Change End
+
+    // Disallow Attacking
+    // For some reaon, OnAttackAttempt eats OnShootAttempt. Uhhh It still works I guess.
+    /*
+    private void OnShootAttempt(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, ref ShotAttemptedEvent args)
+    {
+        if (siliconDeadComp.Dead)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("ipc-cant-shoot"), uid, uid);
+            args.Cancel();
+        }
+    }
+    */
+
+    private void OnAttackAttempt(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, AttackAttemptEvent args)
+    {
+	    if (args.Disarm)
+            return;
+        if (siliconDeadComp.Dead)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("ipc-cant-attack"), uid, uid);
+            args.Cancel();
+        }
+    }
+
+    // Disallow Speaking - Only whispers go through. Replace with low batter accent instead? Being able to shout is intentional.
+    private void OnSpeakAttempt(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, SpeakAttemptEvent args)
+    {
+        //Ignore this if theres still battery
+        if (!siliconDeadComp.Dead)
+            return;
+        // Let MutingSystem handle the event for puppets and muted characters (mimes included)
+        if (HasComp<VentriloquistPuppetComponent>(uid) || HasComp<MutedComponent>(uid))
+            return;
+
+        // If the entity has Hypophonia, let that handle it
+        if (HasComp<HypophoniaComponent>(uid))
+            return;
+
+        // If the entity is whispering, let them speak
+        if (args.Whisper)
+            return;
+
+        // Cancel the event and show the popup
+        _popupSystem.PopupEntity(Loc.GetString("speech-hypophonia"), uid, uid);
+        args.Cancel();
+    }
+
+// Box Change End
 }
 
 /// <summary>

--- a/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
+++ b/Content.Server/_EE/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
@@ -8,8 +8,6 @@ using Content.Shared.Humanoid;
 using Content.Shared.StatusEffectNew; // starcup
  // Box Change Start - IPC No Battery Refactor
 using Content.Shared.Stunnable;
-using Content.Shared.Weapons.Ranged.Events;
-using Content.Shared.Interaction.Events;
 using Content.Shared.Puppet;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Muting;
@@ -38,8 +36,6 @@ public sealed class SiliconDeathSystem : EntitySystem
 
     // Box Change Start - IPC No Battery Refactor
         SubscribeLocalEvent<SiliconDownOnDeadComponent, StandUpAttemptEvent>(OnStandUpAttempt);
-        SubscribeLocalEvent<SiliconDownOnDeadComponent, AttackAttemptEvent>(OnAttackAttempt);
-        // SubscribeLocalEvent<SiliconDownOnDeadComponent, ShotAttemptedEvent>(OnShootAttempt);
         SubscribeLocalEvent<SiliconDownOnDeadComponent, SpeakAttemptEvent>(OnSpeakAttempt);
     // Box Change End
     }
@@ -107,30 +103,6 @@ public sealed class SiliconDeathSystem : EntitySystem
     {
         if (siliconDeadComp.Dead)
             args.Cancelled = true;
-    }
-
-    // Disallow Attacking
-    // For some reaon, OnAttackAttempt eats OnShootAttempt. Uhhh It still works I guess.
-    /*
-    private void OnShootAttempt(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, ref ShotAttemptedEvent args)
-    {
-        if (siliconDeadComp.Dead)
-        {
-            _popupSystem.PopupEntity(Loc.GetString("ipc-cant-shoot"), uid, uid);
-            args.Cancel();
-        }
-    }
-    */
-
-    private void OnAttackAttempt(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, AttackAttemptEvent args)
-    {
-	    if (args.Disarm)
-            return;
-        if (siliconDeadComp.Dead)
-        {
-            _popupSystem.PopupEntity(Loc.GetString("ipc-cant-attack"), uid, uid);
-            args.Cancel();
-        }
     }
 
     // Disallow Speaking - Only whispers go through. Replace with low batter accent instead? Being able to shout is intentional.

--- a/Resources/Locale/en-US/_Box/ipc/ipc.ftl
+++ b/Resources/Locale/en-US/_Box/ipc/ipc.ftl
@@ -1,0 +1,1 @@
+ipc-cant-attack = ERROR: Insufficiient power to attack!

--- a/Resources/Locale/en-US/_Box/ipc/ipc.ftl
+++ b/Resources/Locale/en-US/_Box/ipc/ipc.ftl
@@ -1,1 +1,0 @@
-ipc-cant-attack = ERROR: Insufficiient power to attack!

--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -88,7 +88,7 @@
       3: 1
       2: 0.80
       1: 0.45
-      0: 0.00
+      0: 0.2 # Box Chang - Allow batteryless IPCs to crawl
   - type: BatteryDrinker
   # - type: EncryptionKeyHolder # Harmony Change, Comments out intrinsic radio
     # keySlots: 4 # Harmony Change, Comments out intrinsic radio


### PR DESCRIPTION
## About the PR
https://github.com/ss14-boxstation/ss14-boxstation/pull/55 allowed IPCs to remove their own batteries, however this has created an issue where its really easy for players to near-RR themselves in the intuitive pathway for battery upgrades.

Thus, IPCs are no longer force-slept when they have no charge. Instead, they are knocked down and prevented from standing up, as well as they cannot talk louder than a whisper.

## Why / Balance
There is no need for IPCs to be the only species in the game that can be RR'd without taking damage. They have no "absurd strength" that would justify this, and even if they did that is design philosophy we want to move away from.

This maintains EMPs as a viable pathway for Antagonists to make dealing with IPC targets easier without feeling unfair or unfun to the IPC player.

To be frank, its just not fun to run out of battery and be force slept. There was an incident where a Scientist was hit with an EMP artifact, and would have been out of the round without admin intervention. This is unacceptable.

Even Borgs are able to move when they have no power, so it feels strang and unfair that IPCs can't.

## Technical details
The IPC dead battery code was changed to Knockdown the IPC and cancel Stand Up Attempts, as well as reusing Hypophonia code to prevent IPCs from talking at full volume. They can still scream.

The IPC yaml was changed so that IPCs can move when they have no battery. They are just very slow.

## Media
<img width="1369" height="654" alt="image" src="https://github.com/user-attachments/assets/249807d3-ed45-4000-8983-9b247f1f36c1" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: IPCs now have more agency when they have no power.
