### PR TITLE
Readd Bleeding healing to Welders for IPCs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -116,7 +116,6 @@
         Brute: -15 # 5 for each, like a bruise pack
       types:
         Cold: -1 # Structural Repair
-    # bleedingModifier: -20 # DeltaV - IPCs bleed
     bleedingModifier: -2 # Weak but does something, should take 5 doafters to stop full bleedstacks
 # Box Change Ends
 

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -117,7 +117,7 @@
       types:
         Cold: -1 # Structural Repair
     # bleedingModifier: -20 # DeltaV - IPCs bleed
-    bleedingModifier: -2 # Weak but does something
+    bleedingModifier: -2 # Weak but does something, should take 5 doafters to stop full bleedstacks
 # Box Change Ends
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -117,7 +117,7 @@
       types:
         Cold: -1 # Structural Repair
     # bleedingModifier: -20 # DeltaV - IPCs bleed
-    # bleedingModifier: -10 # Parity with Gauze
+    bleedingModifier: -2 # Weak but does something
 # Box Change Ends
 
 - type: entity


### PR DESCRIPTION
## About the PR
Readded Bleeding healing to Welders for IPC healing.

## Why / Balance
It felt weird that it didn't stop bleeding, and its removal was too large of a nerf swing given how hard it is to get welding protection and a good welder as an IPC.

Welders stop bleeding at 1/5th the rate of Chassis Patches (which have the same bleed stopping rate as gauze)

## Technical details

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
**Changelog**
:cl:
- tweak: Welders now slightly stop IPC bleeding

