### PR TITLE
Minor SynthChem Effect Tweaks

### DIFF
--- a/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
+++ b/Resources/Prototypes/_Box/Reagents/medicine_synthetic.yml
@@ -104,13 +104,21 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 6
+          min: 0
+          max: 15
         - !type:TotalDamage
-          min: 60
+          min: 80
         damage:
           types:
             Heat: -3
-            Shock: 0.1
+            Blunt: -1
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
+        damage:
+          types:
+            Shock: 3
       - !type:GenericStatusEffect
         key: Stun
         time: 0.75
@@ -255,11 +263,29 @@
           type: Synthetic
         reagent: SpaceLube
         amount: -3.0
+      - !type:AdjustReagent
+        conditions:
+        - !type:OrganType
+          type: Synthetic
+        reagent: Mechazine
+        amount: -3.0
+      - !type:AdjustReagent
+        conditions:
+        - !type:OrganType
+          type: Synthetic
+        reagent: Synthanol
+        amount: -0.5
     Industrial:
       effects:
       - !type:AdjustReagent
         reagent: SpaceLube
         amount: -3.0
+      - !type:AdjustReagent
+        reagent: Mechazine
+        amount: -3.0
+      - !type:AdjustReagent
+        reagent: Synthanol
+        amount: -0.5
 
 # Routine Maintenance - RoboTrico
 - type: reagent
@@ -279,11 +305,11 @@
           max: 60
         damage:
           groups:
-            Brute: -0.45
+            Brute: -0.6
           types:
-            Heat: -0.15
-            Shock: -0.15
-            Cold: -0.15
+            Heat: -0.2
+            Shock: -0.2
+            Cold: -0.2
 
 # Nanoweldite - Discount Omni for brutes, hard but possible to make
 - type: reagent
@@ -425,8 +451,8 @@
       - !type:HealthChange
         damage:
           types:
-            Cold: -0.05
-            Heat: -0.05
+            Cold: -0.5
+            Heat: -0.5
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature


### PR DESCRIPTION
## About the PR
Tweaked the effects of a handful of SynthChem reagents

## Why / Balance
These chems were underpowered, undertuned, mistuned, or otherwise in need of tweaks.

Tweaks made:
- Degreaser now also removes Mechazine and Synthanol
- Routine Maintenance now heals 0.2 per half unit as opposed to 0.15 per half unit
- Thermal Paste now heals for 0.5 Cold and 0.5 Heat per half unit as opposed to 0.05 Cold and 0.05 Heat per half unit
- Overclocker has been reworked to function better in the environments it was intended for
  - The damage threshold was raised to 80
  - Shock damage was moved to an OD effect, and subsequently increased to 3 damage per half unit
  - Overclocker now ODs at 15u, and it no longer has a minimum reagent threshold
  - Overclocker now also heals 1 Blunt per half unit

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="658" height="595" alt="Screenshot 2026-01-05 043322" src="https://github.com/user-attachments/assets/7e04b8e0-9b24-49e9-8f24-12a58ed80fbd" />

<img width="655" height="348" alt="Screenshot 2026-01-05 042648" src="https://github.com/user-attachments/assets/27dab431-2d44-49ce-a438-786838875bc9" />

<img width="654" height="506" alt="Screenshot 2026-01-05 043029" src="https://github.com/user-attachments/assets/63c5879f-791d-41e3-9dba-2f6ee3406573" />

<img width="658" height="436" alt="Screenshot 2026-01-05 042633" src="https://github.com/user-attachments/assets/998123bf-36ae-4fea-a426-b40bd3e0abab" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Overclocker, Thermal Paste, and Routine Maintenance have all had their effects tweaked to be more useable
- tweak: Degreaser now also removes Mechazine and Synthanol

