### PR TITLE
Add ChillShift Game Preset for Chill Tuesday

### DIFF
--- a/Resources/Locale/en-US/_Box/game-ticking/game-presets/preset-chillshift.ftl
+++ b/Resources/Locale/en-US/_Box/game-ticking/game-presets/preset-chillshift.ftl
@@ -1,0 +1,2 @@
+chillshift-title = Chill Shift
+chillshift-description = RP-oriented low-stakes experience.

--- a/Resources/Prototypes/_Box/GameRules/events.yml
+++ b/Resources/Prototypes/_Box/GameRules/events.yml
@@ -1,0 +1,13 @@
+- type: entityTable
+  id: BasicChillEventsTable
+  table: !type:AllSelector
+    children:
+    - id: AnomalySpawn
+    - id: BluespaceArtifact
+    - id: BluespaceLocker
+    - id: CockroachMigration
+    - id: MassHallucinations
+    - id: MouseMigration
+    - id: RandomSentience
+    - id: SolarFlare
+    - id: ClosetSkeleton

--- a/Resources/Prototypes/_Box/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Box/GameRules/roundstart.yml
@@ -1,0 +1,18 @@
+- type: entityTable
+  id: ChillGameRulesTable
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: BasicChillEventsTable
+    - !type:NestedSelector
+      tableId: CalmPestEventsTable
+    - !type:NestedSelector
+      tableId: CargoGiftsTable
+
+- type: entity
+  id: ChillStationEventsScheduler
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: ChillGameRulesTable

--- a/Resources/Prototypes/_Box/game_presets.yml
+++ b/Resources/Prototypes/_Box/game_presets.yml
@@ -1,0 +1,10 @@
+- type: gamePreset
+  id: ChillShift
+  name: chillshift-title
+  showInVote: false
+  description: chillshift-description
+  rules:
+  - SpaceTrafficControlFriendlyEventScheduler
+  - BasicRoundstartVariation
+  - MeteorSwarmScheduler
+  - ChillStationEventsScheduler


### PR DESCRIPTION
## About the PR
Adds a custom Game Preset for Chill Tuesday

## Why / Balance
admin tool.

Greenshift is too boring, Extended is too dangerous, there is no preset that genuinely feels optimal for RP.

ChillShift allows for:
- Random Anomalies
- Random Artifacts
- Bluespace Lockers
- Harmless Fauna Migration
- Random Sentience
- Solar Flare
- Closet Skeleton
- Friendly Shuttles
- Meteors
- Round start variation

The Extended table was used as a base. All explicitly antagonistic events were removed, all anti-RP events were removed. Gas leak was not included due to accidental trit-flood likelihood seeing as Chill Tuesdays are supposed to feature 0 RR. All anti-fun events were removed (Beurocratic Error, Clerical Error, Powernet, APC Toggle, etc.).

The events kept should allow for mechanical interest, immersion, and RP.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="471" height="551" alt="image" src="https://github.com/user-attachments/assets/6a1216f3-10e9-497a-9b86-4fbe46e2058a" />

<img width="443" height="285" alt="Screenshot 2026-01-07 011341" src="https://github.com/user-attachments/assets/17aee214-f943-40cf-8f20-60afcf43de2e" />

<img width="457" height="436" alt="Screenshot 2026-01-07 012322" src="https://github.com/user-attachments/assets/ab4599ef-3427-49de-b9e6-f68d2c1f60dd" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
_Not player facing._