### PR TITLE
[FIX] Fix IPCs instadraining batteries when standing

### DIFF
--- a/Content.Server/_EE/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EE/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -213,7 +213,7 @@ public sealed class SiliconChargeSystem : EntitySystem
             !TryComp(silicon, out InputMoverComponent? input))
             return 0;
 
-        if (input.HeldMoveButtons == MoveButtons.None || _jetpack.IsUserFlying(silicon)) // If nothing is being held or jet packing
+        if (input.HeldMoveButtons == MoveButtons.None || _jetpack.IsUserFlying(silicon) || movement.CurrentSprintSpeed == 0) // If nothing is being held or jet packing. starcup: Or speed is 0, which will cause a NaN and instantly drain the battery
         {
             return siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction * (-1); // Reduces draw by idle drain reduction
         }


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
Ports a fix from starcup [#524](https://github.com/teamstarcup/starcup/pull/524). This fixes IPCs instantly draining their battery when standing still.

## Technical details
<!-- Summary of code changes for easier review. -->
Read original PR.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed IPCs instantly draining their battery when standing still
