### PR TITLE
Fixes the VGRoid not spawning Loot

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.EntityTableDunGen.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.EntityTableDunGen.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.NPC.Systems;
 using Content.Shared.EntityTable;
+using Content.Shared.EntityTable.EntitySelectors; // Box Change - Earlymerge VGRoid Loot Fix
 using Content.Shared.Physics;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.DungeonLayers;
@@ -36,7 +37,10 @@ public sealed partial class DungeonJob
                 if (!ValidateResume())
                     return;
 
-                if (reservedTiles.Contains(tile))
+            // Box Change Start - Earlymerge VGRoid Loot Fix
+                // if (reservedTiles.Contains(tile))
+                if (reservedTiles.Contains(tile) && !gen.IgnoreReserved)
+            // Box Change End
                     continue;
 
                 if (!_anchorable.TileFree((_gridUid, _grid),

--- a/Content.Shared/Procedural/DungeonLayers/EntityTableDunGen.cs
+++ b/Content.Shared/Procedural/DungeonLayers/EntityTableDunGen.cs
@@ -24,4 +24,14 @@ public sealed partial class EntityTableDunGen : IDunGenLayer
     /// </summary>
     [DataField]
     public bool PerDungeon;
+
+// Box Change Start - Earlymerge VGRoid Loot Fix
+
+    /// <summary>
+    /// Should the spawner ignore reserved tiles.
+    /// </summary>
+    [DataField]
+    public bool IgnoreReserved;
+
+// Box Change End
 }

--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -157,22 +157,38 @@
   - !type:EntityTableDunGen
     minCount: 25
     maxCount: 40
+    # Box Change Start - Earlymerge VGRoid Loot Fix
+    perDungeon: true
+    ignoreReserved: true
+    # Box Change End
     table: !type:NestedSelector
       tableId: SalvageScrapSpawnerCommon
   - !type:EntityTableDunGen
     minCount: 30
     maxCount: 40
+    # Box Change Start - Earlymerge VGRoid Loot Fix
+    perDungeon: true
+    ignoreReserved: true
+    # Box Change End
     table: !type:NestedSelector
       tableId: SalvageScrapSpawnerValuable
   - !type:EntityTableDunGen
     minCount: 15 #Box Change - 30 --> 15 - reverts changes made in upstream pr #37561
     maxCount: 25 #Box Change - 45 --> 25 - reverts changes made in upstream pr #37561
+    # Box Change Start - Earlymerge VGRoid Loot Fix
+    perDungeon: true
+    ignoreReserved: true
+    # Box Change End
     table: !type:NestedSelector
       tableId: SalvageTreasureSpawnerCommon
   - !type:EntityTableDunGen
   #Start of Box specific changes - adds back salvage equipment
     minCount: 15 #30 --> 15
     maxCount: 25 #45 --> 25
+    # Earlymerge VGRoid Loot Fix Start
+    perDungeon: true
+    ignoreReserved: true
+    # Earlymerge VGRoid Loot Fix Start End
     table: !type:NestedSelector
       tableId: SalvageEquipmentSpawnerCommon
   - !type:EntityTableDunGen
@@ -185,6 +201,10 @@
   - !type:EntityTableDunGen
     minCount: 15
     maxCount: 20
+    # Earlymerge VGRoid Loot Fix Start
+    perDungeon: true
+    ignoreReserved: true
+    # Earlymerge VGRoid Loot Fix Start End
     table: !type:NestedSelector
       tableId: SalvageEquipmentSpawnerValuable
       #End of Box specific changes - adds back salvage equipment


### PR DESCRIPTION
## About the PR
Early ports https://github.com/space-wizards/space-station-14/pull/39269 from WizDen

## Why / Balance
- We are planning to keep the Roid for the forseeable future
- There are still active incentives for Salvagers to go to the Roid currently
- Without this, there is not a lot of useful to the station items to be found in the Roid complex
- Noted as a bug on WizDen

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="1244" height="873" alt="Screenshot 2026-02-26 135153" src="https://github.com/user-attachments/assets/cfc8668c-d64f-40dc-9449-a73f790963ae" />
<img width="1433" height="946" alt="Screenshot 2026-02-26 135340" src="https://github.com/user-attachments/assets/c53d5d06-1acc-4962-bcb7-98734d4e534c" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes


**Changelog**
:cl:
- fix: Loot spawns on the VGRoid again.

