### PR TITLE
Minor backend tweaks to Game presets

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -3,6 +3,7 @@
   name: roles-antag-nuclear-operative-name
   antagonist: true
   setPreference: true
+  visiblePreference: true # Box Change - Needed to make Nukies work
   objective: roles-antag-nuclear-operative-objective
   requirements:
   - !type:OverallPlaytimeRequirement
@@ -14,6 +15,7 @@
   name: roles-antag-nuclear-operative-agent-name
   antagonist: true
   setPreference: true
+  visiblePreference: true # Box Change - Needed to make Nukies work
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:OverallPlaytimeRequirement
@@ -28,6 +30,7 @@
   name: roles-antag-nuclear-operative-commander-name
   antagonist: true
   setPreference: true
+  visiblePreference: true # Box Change - Needed to make Nukies work
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement

--- a/Resources/Prototypes/_Box/Roles/Antags/preferences.yml
+++ b/Resources/Prototypes/_Box/Roles/Antags/preferences.yml
@@ -12,49 +12,18 @@
   - !type:OverallPlaytimeRequirement
     time: 3600 # 1h
 
-## Nukies/LoneOp
-- type: antag
-  id: DummyNukeOps
-  name: roles-antag-nuclear-operative-name
-  antagonist: true
-  setPreference: true
-  visiblePreference: true
-  objective: roles-antag-nuclear-operative-objective
-  guides: [NuclearOperatives]
-  requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
-
-## Syndie
-- type: antag
-  id: DummyNukeOpsMed
-  name: roles-antag-nuclear-operative-agent-name
-  antagonist: true
-  setPreference: true
-  visiblePreference: true
-  objective: roles-antag-nuclear-operative-agent-objective
-  guides: [NuclearOperatives]
-  requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
-  - !type:RoleTimeRequirement
-    role: JobChemist
-    time: 10800 # 3h
-
-- type: antag
-  id: DummyNukeOpsCommander
-  name: roles-antag-nuclear-operative-commander-name
-  antagonist: true
-  setPreference: true
-  visiblePreference: true
-  objective: roles-antag-nuclear-operative-commander-objective
-  guides: [NuclearOperatives]
-  requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 18000 # 5h
+## LoneOp
+#- type: antag
+#  id: DummyNukeOps
+#  name: roles-antag-box-lone-operative-name
+#  antagonist: true
+#  setPreference: true
+#  visiblePreference: true
+#  objective: roles-antag-box-lone-operative-objective
+#  guides: [NuclearOperatives]
+#  requirements:
+#  - !type:OverallPlaytimeRequirement
+#    time: 18000 # 5h
 
 ## Syndie
 - type: antag
@@ -113,5 +82,5 @@
   name: consent-be-rr-target
   antagonist: true
   setPreference: true
-  visiblePreference: true # Turn this on if you want this feature. Disabled while we have limited control over tot objectives
+  visiblePreference: true
   objective: consent-be-rr-target-desc

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -110,7 +110,7 @@
   description: dynamic-description
   rules:
   - DynamicRule
-  - DummyNonAntag
+  # - DummyNonAntag # Box Change - Remove Dummy Antag
   - DynamicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -147,11 +147,11 @@
   description: traitor-description
   showInVote: false
   rules:
-  - DummyNonAntagChance
+  # - DummyNonAntagChance # Box Change - Remove Dummy Antag
   - Traitor
   # Harmony Start - reenableds midround
   #- SubGamemodesRuleNoWizard
-  - SubGamemodesRule
+  # - SubGamemodesRule # Box Change - Remove Sub Gamemodes
   # Harmony end
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
@@ -180,10 +180,10 @@
   showInVote: false
   rules:
   - Nukeops
-  - DummyNonAntagChance
+  # - DummyNonAntagChance # Box Change - Remove Dummy Antag
   # Harmony start - reactivates wizard midround
   #- SubGamemodesRuleNoWizard
-  - SubGamemodesRule
+  # - SubGamemodesRule # Box Change - Remove Sub Gamemodes
   # Harmony End
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
@@ -200,11 +200,11 @@
   description: rev-description
   showInVote: false
   rules:
-  - DummyNonAntagChance
+  # - DummyNonAntagChance # Box Change - Remove Dummy Antag
   - Revolutionary
   # Harmony start - reactivates wizard midround even if revs are bye bye
   #- SubGamemodesRuleNoWizard
-  - SubGamemodesRule
+  # - SubGamemodesRule # Box Change - Remove Sub Gamemodes
   # Harmony end
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
@@ -220,8 +220,8 @@
   showInVote: false
   rules:
   - Wizard
-  - DummyNonAntagChance
-  - SubGamemodesRuleNoWizard #No Dual Wizards at the start, midround is fine
+  # - DummyNonAntagChance # Box Change - Remove Dummy Antag
+  # - SubGamemodesRuleNoWizard #No Dual Wizards at the start, midround is fine # Box Change - Remove Sub Gamemodes
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -236,8 +236,8 @@
   showInVote: false
   rules:
   - Xenoborgs
-  - DummyNonAntagChance
-  - SubGamemodesRuleNoWizardNoXenoborg # no two motherships
+  # - DummyNonAntagChance # Box Change - Remove Dummy Antag
+  # - SubGamemodesRuleNoWizardNoXenoborg # no two motherships # Box Change - Remove Sub Gamemodes
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,14 +1,19 @@
 - type: weightedRandom
   id: Secret
   weights:
+# Box Change Start - Completely rework
 # Harmony Changes
-    Traitor: 0.53
-    Conspiracy: 0.1
-    Nukeops: 0.13
-    Survival: 0.08
-    Extended: 0.08
-    Zombie: 0.06
-    Zombieteors: 0.02
+    # Traitor: 0.53
+    # Conspiracy: 0.1
+    # Nukeops: 0.13
+    # Survival: 0.08
+    # Extended: 0.08
+    # Zombie: 0.06
+    # Zombieteors: 0.02
 # Harmony change. Remove Wizard and Kessler from the pool.
 #   Wizard: 0.04
 #   KesslerSyndrome: 0.01
+    Nukeops: 0.13
+    Survival: 0.26
+    Extended: 0.61
+# Box Change End

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -14,6 +14,7 @@
 #   Wizard: 0.04
 #   KesslerSyndrome: 0.01
     Nukeops: 0.13
-    Survival: 0.26
-    Extended: 0.61
+    Survival: 0.13
+    Chillshift: 0.21
+    Extended: 0.53
 # Box Change End


### PR DESCRIPTION
## About the PR
Tweaked a handful of backend stuff.

## Why / Balance
Currently, if an Admin forgets to set the game preset, theres a high chance for random people to become antags. This is not good.
Also, there is currently no way to actually run Nukies if we desire to run Nukies.

(While this adds Survival and NukeOps to the pool for Secret, these are still in need of further work before being viable to actually use as options)

## Technical details
Cuts the Secret game preset pool down to NukeOps at 13%, Survival at 13%, Chillshift at 21% and Extended at 53%.

Returns the Nukies antag buttons to the mechanical ones.

Removes all Sub-Gamemodes from rolling.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
