### PR TITLE
Removes certain events from the Chillshift preset

### DIFF
--- a/Resources/Prototypes/_Box/GameRules/events.yml
+++ b/Resources/Prototypes/_Box/GameRules/events.yml
@@ -5,9 +5,9 @@
     - id: AnomalySpawn
     - id: BluespaceArtifact
     - id: BluespaceLocker
-    - id: CockroachMigration
+    # - id: CockroachMigration
     - id: MassHallucinations
-    - id: MouseMigration
+    # - id: MouseMigration
     - id: RandomSentience
     - id: SolarFlare
-    - id: ClosetSkeleton
+    # - id: ClosetSkeleton

--- a/Resources/Prototypes/_Box/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Box/GameRules/roundstart.yml
@@ -4,8 +4,8 @@
     children:
     - !type:NestedSelector
       tableId: BasicChillEventsTable
-    - !type:NestedSelector
-      tableId: CalmPestEventsTable
+    # - !type:NestedSelector
+    #   tableId: CalmPestEventsTable
     - !type:NestedSelector
       tableId: CargoGiftsTable
 


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
Removes Skeleton and Vent Critters from Chillshift

## Why / Balance
Vent Critters puts up a Scary Announcement. Skeletons are Free Agents.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
