### PR TITLE
Removes doors and other machines randomly having wires cut at roundstart

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -559,7 +559,7 @@
     - id: BasicTrashVariationPass
     - id: SolidWallRustingVariationPass
     - id: ReinforcedWallRustingVariationPass
-    - id: CutWireVariationPass
+    # - id: CutWireVariationPass # Box Change - Removes doors and other machines randomly having wires cut at roundstart
     - id: BasicPuddleMessVariationPass
       prob: 0.99
       orGroup: puddleMess


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
Reverts https://github.com/space-wizards/space-station-14/pull/41191

## Why / Balance
Randomly having doors shocked isn't fun, Sec thinks its antag behaviour or Malf AI, and it makes holopads ugly as sin. I don't even think Engis fix them, either, in most cases.

## Technical details
Comments out one line of yaml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes


**Changelog**

