### PR TITLE
Reverts WizDen "Trip APCs when they exceed a power limit"

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml
@@ -19,7 +19,7 @@
                         <!-- Power On/Off -->
                         <Label Text="{Loc 'apc-menu-breaker-label'}" HorizontalExpand="True"
                                 StyleClasses="highlight" MinWidth="120"/>
-                        <BoxContainer Orientation="Horizontal" MinWidth="150">
+                        <BoxContainer Orientation="Horizontal" MinWidth="90"> <!--Box Change - Reverts APC Breaker Tripping - 150 > 90-->
                             <Button Name="BreakerButton" Text="{Loc 'apc-menu-breaker-button'}" HorizontalExpand="True" ToggleMode="True"/>
                         </BoxContainer>
                         <!--Charging Status-->

--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -40,14 +40,17 @@ namespace Content.Client.Power.APC.UI
 
             if (PowerLabel != null)
             {
-                if (castState.Tripped)
+            // Box Change Start - Reverts APC Breaker Tripping
+                /* if (castState.Tripped)
                 {
                     PowerLabel.Text = Loc.GetString("apc-menu-power-state-label-tripped");
                 }
                 else
                 {
                     PowerLabel.Text = Loc.GetString("apc-menu-power-state-label-text", ("power", castState.Power), ("maxLoad", castState.MaxLoad));
-                }
+                } */
+                PowerLabel.Text = Loc.GetString("apc-menu-power-state-label-text", ("power", castState.Power));
+            // Box Change End
             }
 
             if (ExternalPowerStateLabel != null)

--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -97,7 +97,8 @@ public sealed class StationPowerTests
         await pair.CleanReturnAsync();
     }
 
-    [Test, TestCaseSource(nameof(GameMaps))]
+// Box Change Start - Reverts APC Breaker Tripping
+    /* [Test, TestCaseSource(nameof(GameMaps))]
     public async Task TestApcLoad(string mapProtoId)
     {
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
@@ -144,5 +145,6 @@ public sealed class StationPowerTests
         });
 
         await pair.CleanReturnAsync();
-    }
+    } */
+// Box Change End
 }

--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Power.Components;
 
-[RegisterComponent, AutoGenerateComponentPause]
+[RegisterComponent/*, AutoGenerateComponentPause*/] // Box Change - Reverts APC Breaker Tripping
 public sealed partial class ApcComponent : BaseApcNetComponent
 {
     [DataField("onReceiveMessageSound")]
@@ -34,6 +34,8 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     public const float HighPowerThreshold = 0.9f;
     public static TimeSpan VisualsChangeDelay = TimeSpan.FromSeconds(1);
 
+// Box Change Start - Reverts APC Breaker Tripping
+/*
     /// <summary>
     /// Maximum continuous load in Watts that this APC can supply to loads. Exceeding this starts a
     /// timer, which after enough overloading causes the APC to "trip" off.
@@ -59,6 +61,8 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     /// </summary>
     [DataField]
     public bool TripFlag;
+*/
+// Box Change End
 
     // TODO ECS power a little better!
     // End the suffering

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -59,7 +59,8 @@ public sealed class ApcSystem : EntitySystem
             {
                 UpdateApcState(uid, apc, battery);
             }
-
+        // Box Change Start - Reverts APC Breaker Tripping
+            /*
             // Overload
             if (apc.MainBreakerEnabled && battery.CurrentSupply > apc.MaxLoad)
             {
@@ -81,6 +82,8 @@ public sealed class ApcSystem : EntitySystem
             {
                 apc.TripStartTime = null;
             }
+            */
+        // Box Change End
         }
     }
 
@@ -137,8 +140,13 @@ public sealed class ApcSystem : EntitySystem
         apc.MainBreakerEnabled = !apc.MainBreakerEnabled;
         battery.CanDischarge = apc.MainBreakerEnabled;
 
+
+    // Box Change Start - Reverts APC Breaker Tripping
+        /*
         if (apc.MainBreakerEnabled)
             apc.TripFlag = false;
+        */
+    // Box Change End
 
         UpdateUIState(uid, apc);
         _audio.PlayPvs(apc.OnReceiveMessageSound, uid, AudioParams.Default.WithVolume(-2f));
@@ -209,10 +217,13 @@ public sealed class ApcSystem : EntitySystem
         var charge = ContentHelpers.RoundToNearestLevels(battery.CurrentStorage / battery.Capacity, 1.0, 100 / ChargeAccuracy) / 100f * ChargeAccuracy;
 
         var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled,
-            (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
-            charge,
+            (int)MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
+            // Box Change Start - Reverts APC Breaker Tripping
+            /* charge,
             apc.MaxLoad,
-            apc.TripFlag);
+            apc.TripFlag); */
+            charge);
+        // Box Change End
 
         _ui.SetUiState((uid, ui), ApcUiKey.Key, state);
     }

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -181,17 +181,24 @@ namespace Content.Shared.APC
         public readonly int Power;
         public readonly ApcExternalPowerState ApcExternalPower;
         public readonly float Charge;
-        public readonly float MaxLoad;
-        public readonly bool Tripped;
+        // Box Change Start - Reverts APC Breaker Tripping
+        /* public readonly float MaxLoad;
+        public readonly bool Tripped; */
+        // Box Change End
 
-        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge, float maxLoad, bool tripped)
+    // Box Change Start - Reverts APC Breaker Tripping
+        // public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge, float maxLoad, bool tripped)
+        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge)
+    // Box Change End
         {
             MainBreaker = mainBreaker;
             Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;
-            MaxLoad = maxLoad;
-            Tripped = tripped;
+            // Box Change Start - Reverts APC Breaker Tripping
+            /* MaxLoad = maxLoad;
+            Tripped = tripped; */
+            // Box Change End
         }
 
         public bool Equals(ApcBoundInterfaceState? other)
@@ -201,9 +208,12 @@ namespace Content.Shared.APC
             return MainBreaker == other.MainBreaker &&
                    Power == other.Power &&
                    ApcExternalPower == other.ApcExternalPower &&
-                   MathHelper.CloseTo(Charge, other.Charge) &&
+                // Box Change Start - Reverts APC Breaker Tripping
+                   /* MathHelper.CloseTo(Charge, other.Charge) &&
                    MathHelper.CloseTo(MaxLoad, other.MaxLoad) &&
-                   Tripped == other.Tripped;
+                   Tripped == other.Tripped; */
+                   MathHelper.CloseTo(Charge, other.Charge);
+                // Box Change End
         }
 
         public override bool Equals(object? obj)
@@ -213,7 +223,10 @@ namespace Content.Shared.APC
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(MainBreaker, Power, (int) ApcExternalPower, Charge, MaxLoad, Tripped);
+        // Box Change Start - Reverts APC Breaker Tripping
+            // return HashCode.Combine(MainBreaker, Power, (int) ApcExternalPower, Charge, MaxLoad, Tripped);
+            return HashCode.Combine(MainBreaker, Power, (int) ApcExternalPower, Charge);
+        // Box Change End
         }
     }
 

--- a/Resources/Locale/en-US/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/ui/power-apc.ftl
@@ -10,7 +10,10 @@ apc-menu-charge-label = {$percent} Charged
 apc-menu-power-state-good = Good
 apc-menu-power-state-low = Low
 apc-menu-power-state-none = None
-apc-menu-power-state-label-text = { POWERWATTS($power) } / { POWERWATTS($maxLoad) }
+# Box Change Start - Remove APC Breaker Tripping
+# apc-menu-power-state-label-text = { POWERWATTS($power) } / { POWERWATTS($maxLoad) }
+apc-menu-power-state-label-text = { POWERWATTS($power) }
+# Box Change End
 apc-menu-power-state-label-tripped = OVERLOAD
 
 # For the flavor text on the footer


### PR DESCRIPTION
## About the PR
Reverts https://github.com/space-wizards/space-station-14/pull/41377

## Why / Balance
While Mono-APC nets that cover an entire station are an undesirable outcome, this current implementation to remove them doesn't meet the mark for BoxStation.

First, Dual XenoArch may be interfering with later balance patches applied to this.
Second, we do not have the amount of mapping-capable contributors to fix any issues this may have caused for us.
Third, the only solution to an overloaded powernet is to split it or add more APCs. I don't think we should be encouranging APC Arrays.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes


**Changelog**
