### PR TITLE
Allow Thaven to be Accentless

### DIFF
--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -15,6 +15,7 @@
     - type: MothAccent
     - type: ReplacementAccent
       accent: dwarf
+    - type: NoContractionsAccent # Box Change - Accentless Thaven
 
 # 1 Cost
 


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
Allow Thaven to take the accentless trait and it to function in removing their anti-contraction accent

## Why / Balance
Intended effect of trait

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="994" height="298" alt="image" src="https://github.com/user-attachments/assets/1fff09ac-1cd5-4568-ad77-3136fe12b3cb" />


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Accentless now correctly applies to Thaven
