### PR TITLE
Ports Savior Clones from ImpStation

### DIFF
--- a/Resources/Locale/en-US/_Impstation/objectives/conditions/kill-head.ftl
+++ b/Resources/Locale/en-US/_Impstation/objectives/conditions/kill-head.ftl
@@ -1,0 +1,1 @@
+objective-condition-kill-head-paradox-title = Kill the real {$targetName}, {CAPITALIZE($job)}

--- a/Resources/Locale/en-US/_Impstation/objectives/conditions/save-head.ftl
+++ b/Resources/Locale/en-US/_Impstation/objectives/conditions/save-head.ftl
@@ -1,0 +1,3 @@
+objective-condition-save-head-title = Keep {$targetName}, {CAPITALIZE($job)} alive
+
+objective-condition-save-head-paradox-title = Keep the real {$targetName}, {CAPITALIZE($job)} alive

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -218,7 +218,9 @@ ghost-role-information-space-ninja-name = Space Ninja
 ghost-role-information-space-ninja-description = Use stealth and deception to sabotage the station.
 
 ghost-role-information-paradox-clone-name = Paradox Clone
-ghost-role-information-paradox-clone-description = A freak space-time anomaly has teleported you into another reality! Now you have to find your counterpart and kill and replace them.
+# Box Change Start - imp - objective rephrase to account for saviors
+ghost-role-information-paradox-clone-description = A freak space-time anomaly has teleported you into another reality! Confront your counterpart, and protect your own existence.
+# Box Change End
 
 ghost-role-information-syndicate-reinforcement-name = Syndicate Agent
 ghost-role-information-syndicate-reinforcement-description = Someone needs reinforcements. You, the first person the syndicate could find, will help them.

--- a/Resources/Locale/en-US/paradox-clone/role.ftl
+++ b/Resources/Locale/en-US/paradox-clone/role.ftl
@@ -2,6 +2,8 @@ paradox-clone-round-end-agent-name = paradox clone
 
 objective-issuer-paradox = [color=lightblue]Paradox[/color]
 
-paradox-clone-role-greeting = A freak space-time anomaly has teleported you into another reality! Now you have to find your counterpart and kill and replace them. Only one of you two can survive.
+# Box Change Start - imp - objective rephrase to account for saviors
+paradox-clone-role-greeting = A freak space-time anomaly has teleported you into another reality! The version of you from this reality should be around here somewhere. Blend in, but protect your own existence above all! Be sure to check your [bold]objectives[/bold]!
+# Box Change End
 
 paradox-clone-ghost-name-modifier = {$baseName} (clone)

--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -35,7 +35,9 @@ roles-antag-space-ninja-name = Space Ninja
 roles-antag-space-ninja-objective = Use your stealth to sabotage the station, nom on electrical wires.
 
 roles-antag-paradox-clone-name = Paradox Clone
-roles-antag-paradox-clone-objective = A freak space-time anomaly has teleported you into another reality! Now you have to find your counterpart and kill and replace them.
+# Box Change Start - imp - objective rephrase to account for saviors
+roles-antag-paradox-clone-objective = A freak space-time anomaly has teleported you into another reality! Confront your counterpart, and protect your own existence.
+# Box Change End
 
 roles-antag-thief-name = Thief
 roles-antag-thief-objective = Add some NT property to your personal collection without using violence.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -285,10 +285,16 @@
     objectiveBlacklist:
       tags:
       - ParadoxCloneObjectiveBlacklist
-  - type: AntagObjectives
-    objectives:
-    - ParadoxCloneKillObjective
-    - ParadoxCloneLivingObjective
+# Box Change Start - Imp - Saviour PDox
+  # - type: AntagObjectives
+  #   objectives:
+  #   - ParadoxCloneKillObjective
+  #   - ParadoxCloneLivingObjective
+  - type: AntagRandomObjectives # imp
+    sets:
+    - groups: ParadoxTypeGroups
+    maxDifficulty: 2 # will pick two objective
+# Box Change End
   - type: AntagRandomSpawn # TODO: improve spawning so they only start in maints
   - type: AntagSelection
     agentName: paradox-clone-round-end-agent-name

--- a/Resources/Prototypes/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/Objectives/paradoxClone.yml
@@ -5,6 +5,7 @@
   components:
   - type: Objective
     # required but not used
+    unique: true # Box change - imp - Saviour Clones
     difficulty: 1
     issuer: objective-issuer-paradox
   - type: RoleRequirement
@@ -25,6 +26,11 @@
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
   - type: EscapeShuttleCondition
+  - type: ObjectiveBlacklistRequirement # Box change - imp; enabling saviors
+    blacklist:
+      components:
+      - SurviveCondition
+      - KeepAliveCondition
 
 - type: entity
   parent: [BaseParadoxCloneObjective, BaseKillObjective]
@@ -36,5 +42,10 @@
   - type: KillPersonCondition
     requireDead: true
   - type: TargetObjective
-    title: objective-condition-kill-head-title # kill <name>, <job>
+    title: objective-condition-kill-head-paradox-title # kill <name>, <job> # Box Change - imp; Savior clones - objective-condition-kill-head-title > objective-condition-kill-head-paradox-title
+  - type: ObjectiveBlacklistRequirement # Box change - imp; necessary so savior objectives don't get paired with non-savior
+    blacklist:
+      components:
+      - SurviveCondition
+      - KeepAliveCondition
 

--- a/Resources/Prototypes/_Impstation/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/objectiveGroups.yml
@@ -1,0 +1,14 @@
+# paradox anomaly
+
+- type: weightedRandom
+  id: ParadoxTypeGroups
+  weights:
+    ParadoxTypeGroup: 1
+
+- type: weightedRandom
+  id: ParadoxTypeGroup
+  weights:
+    ParadoxCloneKillObjective: 4
+    ParadoxCloneSaveObjective: 1
+    ParadoxCloneLivingAltObjective: 1
+    ParadoxCloneLivingObjective: 1

--- a/Resources/Prototypes/_Impstation/Objectives/paradoxClone.yml
+++ b/Resources/Prototypes/_Impstation/Objectives/paradoxClone.yml
@@ -1,0 +1,41 @@
+
+## support for savior clones
+- type: entity
+  parent: [BaseParadoxCloneObjective, BaseSurviveObjective]
+  id: ParadoxCloneLivingAltObjective
+  name: Keep yourself alive.
+  description: When the shift's over, so is your time in this reality. Don't die (or get too attached) before then.
+  components:
+  - type: Objective
+    icon:
+      sprite: Structures/Furniture/chairs.rsi
+      state: shuttle
+  - type: ObjectiveBlacklistRequirement
+    blacklist:
+      components:
+      - KillPersonCondition
+      - EscapeShuttleCondition
+
+- type: entity
+  parent: [BaseParadoxCloneObjective, BaseKeepAliveObjective]
+  id: ParadoxCloneSaveObjective
+  name: Resolve the paradox.
+  description: You need your original alive to resolve the paradox. Do whatever's necessary to make that happen.
+  components:
+  - type: PickSpecificPerson
+  - type: KeepAliveCondition
+  - type: Objective
+    icon:
+    # Box Change Start - Replace with Sprites we do have
+      # sprite: _Goobstation/Heretic/abilities_heretic.rsi
+      # state: void_phase # seems as good a "paradox"-y sprite as any
+      sprite: Structures/Specific/anomaly.rsi
+      state: anom4
+    # Box Change End
+  - type: ObjectiveBlacklistRequirement
+    blacklist:
+      components:
+      - KillPersonCondition
+      - EscapeShuttleCondition
+  - type: TargetObjective
+    title: objective-condition-save-head-paradox-title # save <name>, <job>


### PR DESCRIPTION
## About the PR
Ports the following ImpStation PRs
- https://github.com/impstation/imp-station-14/pull/2963
- https://github.com/impstation/imp-station-14/pull/3249

## Why / Balance
Paradox Clones are in an interesting spot where to have fun playing them you can't be autovalid to Security, but they have to be autovalid because they exist to RR crew.
Also, as we're a fork that aims to minimize and control RR to be impactful and fun, they stick out.

Savior Clones are a Paradox Clone variant that must keep their original alive at all costs instead. Whether you are or are not a Savior Clone is only visible once you've rolled in to the ghostrole.

The RR objective is 4x more likely than the Savior objective.

By adding Savior clones, it gives RR clones more RP paths to interact with their original, allows for better narratives, and reduces or prevents PDox metagaming.
Security now doesn't just have to identify who is the original, but also if the PDox even wants to kill or not.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="560" height="561" alt="Screenshot 2026-04-14 163112" src="https://github.com/user-attachments/assets/67715b12-4497-4177-b968-9b92c8159280" />
<img width="886" height="509" alt="Screenshot 2026-04-14 163126" src="https://github.com/user-attachments/assets/9353e435-b2ab-43b8-abaa-57eabad30d74" />
<img width="393" height="426" alt="Screenshot 2026-04-14 163203" src="https://github.com/user-attachments/assets/6a8c2990-7dc2-4086-97e8-b680aa83a31a" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- add: Paradox Clones can now spawn with an objective set focused on keeping their other self alive.
