### PR TITLE
Give Paradox Clones a 30% chance to survive round-end, even if they did not complete their objectives

### DIFF
--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -87,6 +87,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         var gibComp = EnsureComp<GibOnRoundEndComponent>(clone.Value);
         gibComp.SpawnProto = ent.Comp.GibProto;
         gibComp.PreventGibbingObjectives = new() { "ParadoxCloneKillObjective" }; // don't gib them if they killed the original.
+        gibComp.SafetyChance = 0.3f; // Box Change: Give Paradox Clones a 30% chance to not gib at round end, even if their objective wasn't completed.
 
         // turn their suit sensors off so they don't immediately get noticed
         _sensor.SetAllSensors(clone.Value, SuitSensorMode.SensorOff);

--- a/Content.Server/Gibbing/Systems/GibOnRoundEndSystem.cs
+++ b/Content.Server/Gibbing/Systems/GibOnRoundEndSystem.cs
@@ -1,8 +1,9 @@
-﻿using Content.Shared.GameTicking;
+using Content.Shared.GameTicking;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Systems;
 using Content.Server.Body.Systems;
+using Robust.Shared.Random; // Box Change: For paraclone RNG
 
 namespace Content.Server.Gibbing.Systems;
 public sealed class GibOnRoundEndSystem : EntitySystem
@@ -10,6 +11,7 @@ public sealed class GibOnRoundEndSystem : EntitySystem
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
+    [Dependency] private readonly IRobustRandom _random = default!; // Box Change: For paraclone RNG 
 
     public override void Initialize()
     {
@@ -42,6 +44,13 @@ public sealed class GibOnRoundEndSystem : EntitySystem
             }
             else
                 gib = true;
+
+            // Start Box Change: Roll for safety, even if their objectives haven't been completed
+            if (_random.Prob(gibComp.SafetyChance))
+            {
+                gib = false;
+            }
+            // End Box Change
 
             if (!gib)
                 continue;

--- a/Content.Shared/Gibbing/Components/GibOnRoundEndComponent.cs
+++ b/Content.Shared/Gibbing/Components/GibOnRoundEndComponent.cs
@@ -27,3 +27,4 @@ public sealed partial class GibOnRoundEndComponent : Component
     [DataField]
     public float SafetyChance = 0f;
     // End Box Change}
+}

--- a/Content.Shared/Gibbing/Components/GibOnRoundEndComponent.cs
+++ b/Content.Shared/Gibbing/Components/GibOnRoundEndComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Prototypes;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Gibbing.Components;
 
@@ -19,4 +19,11 @@ public sealed partial class GibOnRoundEndComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId? SpawnProto;
-}
+
+    // Start Box Change
+    /// <summary>
+    /// Chance that the entity will not be gibbed, even if their objectives haven't been completed.
+    /// </summary>
+    [DataField]
+    public float SafetyChance = 0f;
+    // End Box Change}

--- a/Resources/Prototypes/_Box/Entities/Mobs/gibonroundend_testing.yml
+++ b/Resources/Prototypes/_Box/Entities/Mobs/gibonroundend_testing.yml
@@ -3,7 +3,7 @@
   id: MobGibOnRoundEnd50
   name: Urist McGibsOnRoundEnd
   description: He gibs on round end, except when he don't
-  suffix: 50%, DEBUG
+  suffix: 50%, DEBUG, Box
   components:
     - type: GibOnRoundEnd
       safetyChance: 0.5
@@ -13,7 +13,7 @@
   id: MobGibOnRoundEnd10
   name: Urist McGibsOnRoundEnd
   description: He gibs on round end, 90% of the time.
-  suffix: 10%, DEBUG
+  suffix: 10%, DEBUG, Box
   components:
     - type: GibOnRoundEnd
       safetyChance: 0.1

--- a/Resources/Prototypes/_Box/Entities/Mobs/gibonroundend_testing.yml
+++ b/Resources/Prototypes/_Box/Entities/Mobs/gibonroundend_testing.yml
@@ -1,0 +1,19 @@
+- type: entity
+  parent: MobHuman
+  id: MobGibOnRoundEnd50
+  name: Urist McGibsOnRoundEnd
+  description: He gibs on round end, except when he don't
+  suffix: 50%, DEBUG
+  components:
+    - type: GibOnRoundEnd
+      safetyChance: 0.5
+
+- type: entity
+  parent: MobHuman
+  id: MobGibOnRoundEnd10
+  name: Urist McGibsOnRoundEnd
+  description: He gibs on round end, 90% of the time.
+  suffix: 10%, DEBUG
+  components:
+    - type: GibOnRoundEnd
+      safetyChance: 0.1


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Made at Bones' suggestion/request, in advance of the coming space law rewrite, where paraclones will be given protected status. And also to help reduce the issue of paraclones being autovalid.
## Technical details
<!-- Summary of code changes for easier review. -->
Added a safetyChance field to GibOnRoundEndComponent, a random number check that uses it in GibOnRoundEndSystem, and a line to set the value to 30% in the Paradox Clone GameRule.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/5fffccac-85b6-49d8-879a-0aab4721fd32

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Paradox Clones now have a chance to survive the end of the round, even if they did not kill their original.
