### PR TITLE
Rodentia once again can be forced to spit out the contents of their cheek storage

### DIFF
--- a/Content.Shared/_DV/Storage/EntitySystems/SharedMouthStorageSystem.cs
+++ b/Content.Shared/_DV/Storage/EntitySystems/SharedMouthStorageSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Stunnable;
 using Robust.Shared.Random;
 using System.Linq;
 using Content.Shared.Popups;
+using Robust.Shared.Player;
 // End Box Change
 
 namespace Content.Shared._DV.Storage.EntitySystems;
@@ -41,7 +42,7 @@ public abstract class SharedMouthStorageSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<MouthStorageComponent, MapInitEvent>(OnMouthStorageInit);
-        SubscribeLocalEvent<MouthStorageComponent, KnockedDownEvent>(DropAllContents);
+        SubscribeLocalEvent<MouthStorageComponent, StunnedEvent>(DropAllContents); // Box Change: Use StunnedEvent instead of KnockedDownEvent so that you don't spit out items when you go prone
         SubscribeLocalEvent<MouthStorageComponent, DisarmedEvent>(DropAllContents);
         SubscribeLocalEvent<MouthStorageComponent, DamageChangedEvent>(OnDamageModified);
         SubscribeLocalEvent<MouthStorageComponent, ExaminedEvent>(OnExamined);
@@ -85,7 +86,8 @@ public abstract class SharedMouthStorageSystem : EntitySystem
             var targetPos = _transformSystem.GetWorldPosition(uid);
             foreach (var ent in contained)
             {
-                _popupSystem.PopupEntity(Loc.GetString("rodentia-cheek-storage-eject", ("rat", Identity.Entity(component.Owner, EntityManager))), uid, PopupType.MediumCaution);
+                _popupSystem.PopupEntity(Loc.GetString("rodentia-cheek-storage-eject-self"), uid, uid, PopupType.MediumCaution); // For whatever reason PopupClientt and PopupPredicted do not work, so we use this instead.
+                _popupSystem.PopupEntity(Loc.GetString("rodentia-cheek-storage-eject-other", ("rat", Identity.Entity(component.Owner, EntityManager))), uid, Filter.PvsExcept(uid), true, PopupType.MediumCaution);
                 var transform = Transform(ent);
                 _transformSystem.SetWorldPositionRotation(ent, targetPos + _random.NextVector2Box() / 4, _random.NextAngle(), transform);
             }

--- a/Content.Shared/_DV/Storage/EntitySystems/SharedMouthStorageSystem.cs
+++ b/Content.Shared/_DV/Storage/EntitySystems/SharedMouthStorageSystem.cs
@@ -16,12 +16,12 @@ using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
-// Box additions start
-using System.Numerics;
-using Content.Shared.Interaction;
+// Start Box Change
 using Content.Shared.Stunnable;
-using Content.Shared.Throwing;
-using Robust.Shared.Physics.Components;
+using Robust.Shared.Random;
+using System.Linq;
+using Content.Shared.Popups;
+// End Box Change
 
 namespace Content.Shared._DV.Storage.EntitySystems;
 
@@ -30,6 +30,11 @@ public abstract class SharedMouthStorageSystem : EntitySystem
     // [Dependency] private readonly DumpableSystem _dumpableSystem = default!; // Box - Removed because broken
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+    // Start Box Change: Additions for DropAllContents refactor
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    // End Box Change
 
     public override void Initialize()
     {
@@ -69,10 +74,23 @@ public abstract class SharedMouthStorageSystem : EntitySystem
 
     private void DropAllContents<T>(EntityUid uid, MouthStorageComponent component, ref T _) // Box Change - Port fix from Starcup
     {
-        if (component.MouthId == null)
-            return;
-
+        // Start Box Change: Complete refactor
+        //if (component.MouthId == null)
+        //    return;
         // _dumpableSystem.DumpContents(component.MouthId.Value, uid, uid);
+        TryComp<StorageComponent>(component.MouthId, out var storage);
+        if (storage != null)
+        {
+            var contained = storage.Container.ContainedEntities.ToArray();
+            var targetPos = _transformSystem.GetWorldPosition(uid);
+            foreach (var ent in contained)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("rodentia-cheek-storage-eject", ("rat", Identity.Entity(component.Owner, EntityManager))), uid, PopupType.MediumCaution);
+                var transform = Transform(ent);
+                _transformSystem.SetWorldPositionRotation(ent, targetPos + _random.NextVector2Box() / 4, _random.NextAngle(), transform);
+            }
+        }
+        //End Box Change
     }
 
     private void OnDamageModified(EntityUid uid, MouthStorageComponent component, DamageChangedEvent args)

--- a/Resources/Locale/en-US/_Box/species/rodentia.ftl
+++ b/Resources/Locale/en-US/_Box/species/rodentia.ftl
@@ -1,1 +1,2 @@
-rodentia-cheek-storage-eject = {CAPITALIZE(THE($rat))} spits something out!
+rodentia-cheek-storage-eject-other = {CAPITALIZE(THE($rat))} spits something out!
+rodentia-cheek-storage-eject-self = You spit out the items in your mouth!

--- a/Resources/Locale/en-US/_Box/species/rodentia.ftl
+++ b/Resources/Locale/en-US/_Box/species/rodentia.ftl
@@ -1,0 +1,1 @@
+rodentia-cheek-storage-eject = {CAPITALIZE(THE($rat))} spits something out!

--- a/Resources/ServerInfo/_Box/Guidebook/Mobs/Rodentia.xml
+++ b/Resources/ServerInfo/_Box/Guidebook/Mobs/Rodentia.xml
@@ -12,7 +12,7 @@
 
   Their unarmed attacks deal a mixture of Blunt and Slash.
 
-  Rodentia can store small objects inside their cheeks. When they have anything inside this storage their speech becomes muffled. If knocked down, disarmed, or sufficiently damaged, [color=yellow]they will spit out any items[/color] stored in their cheeks.
+  Rodentia can store small objects inside their cheeks. When they have anything inside this storage their speech becomes muffled. If stunned, disarmed, or sufficiently damaged, [color=yellow]they will spit out any items[/color] stored in their cheeks.
 
   They take [color=#ffa500]30% more Blunt, 15% more Slash, and 15% more Pierce.[/color]
 

--- a/Resources/ServerInfo/_Box/Guidebook/Mobs/Rodentia.xml
+++ b/Resources/ServerInfo/_Box/Guidebook/Mobs/Rodentia.xml
@@ -12,7 +12,7 @@
 
   Their unarmed attacks deal a mixture of Blunt and Slash.
 
-  Rodentia can store small objects inside their cheeks. When they have anything inside this storage their speech becomes muffled.
+  Rodentia can store small objects inside their cheeks. When they have anything inside this storage their speech becomes muffled. If knocked down, disarmed, or sufficiently damaged, [color=yellow]they will spit out any items[/color] stored in their cheeks.
 
   They take [color=#ffa500]30% more Blunt, 15% more Slash, and 15% more Pierce.[/color]
 


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
When we refactored Rodentia to be based on Funky's implementation, this mechanic was commented out due to being broken by upstream changes, and was never fixed.

As originally intended, Rodentia will now be forced to spit out any items in their cheek storage upon being knocked down, disarmed, or hit for sufficient damage. I've also added a popup message to make it more clear what's happening ("{nane} spits something up!"), and updated the guidebook to reflect the re-implementation of this mechanic.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As brought up on the Discord, with the mechanic being dummied out, Rodentia cheek storage acts as an unsearchable inventory that can be used to hide objective items. This has only never been an issue because Box has few if any Rodentia characters.

This is also, to me, the much preferable solution to allowing the storage to be directly accessible by other players. We do _not_ need to invite the myriad implications that come with someone else shoving objects into your mouth.
## Technical details
<!-- Summary of code changes for easier review. -->
Rewrote SharedMouthStorageSystem.DropAllContents() to actually function. Should match functionality of [the method originally used on Funky.](https://github.com/funky-station/funky-station/blob/master/Content.Shared/Storage/EntitySystems/DumpableSystem.cs#L177)
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/770e93ee-68d4-4e55-b0d6-56da41caa053

https://github.com/user-attachments/assets/147c1b9c-fefe-44e3-872b-1c4922fb331f

https://github.com/user-attachments/assets/7729830d-acb3-4602-bc74-16a5e11b0c98

https://github.com/user-attachments/assets/968bd2f5-e906-4d68-b534-f0d7d641ddef

https://github.com/user-attachments/assets/4b5bfb72-d0c2-4ffc-9375-50d3961b8c67

<img width="674" height="390" alt="SS14 Loader_K4NNRGCA6K" src="https://github.com/user-attachments/assets/88a579b7-d208-4447-9ca5-9bb60a7367f6" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Rodentia will now eject any items in their cheek storage upon being knocked down, disarmed, or taking sufficient damage. Your cheese is no longer safe.
