### PR TITLE
[Port] adds pronouns to manifest

### DIFF
--- a/Content.Client/CrewManifest/UI/CrewManifestSection.cs
+++ b/Content.Client/CrewManifest/UI/CrewManifestSection.cs
@@ -25,26 +25,62 @@ public sealed class CrewManifestSection : BoxContainer
             Text = Loc.GetString(section.Name)
         });
 
-        var gridContainer = new GridContainer()
+        // var gridContainer = new GridContainer() Box - replaces with a box container to better fit long names - for pronoun display
+        var gridContainer = new BoxContainer()
         {
+            Orientation = LayoutOrientation.Horizontal,
             HorizontalExpand = true,
-            Columns = 2
+            // Columns = 2 Box - replaces with a horizontal orientation instead - for pronoun display
         };
+        // Delta-V - Start of column BoxContainers.
+        var namesContainer = new BoxContainer()
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            SizeFlagsStretchRatio = 3,
+        };
+
+        var titlesContainer = new BoxContainer()
+        {
+            Orientation = LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            SizeFlagsStretchRatio = 2,
+        };
+
+        gridContainer.AddChild(namesContainer);
+        gridContainer.AddChild(titlesContainer);
+        // Delta-V - end of column BoxContainers.
 
         AddChild(gridContainer);
 
         foreach (var entry in entries)
         {
-            var name = new RichTextLabel()
+            // var name = new RichTextLabel() Box - Comments out for pronouns pr
+            // Delta-V - start of name and pronoun container
+            var nameContainer = new BoxContainer()
             {
+                Orientation = LayoutOrientation.Horizontal,
                 HorizontalExpand = true,
             };
+            var name = new RichTextLabel();
             name.SetMessage(entry.Name);
+
+            var gender = new RichTextLabel()
+            {
+                Margin = new Thickness(6, 0, 0, 0),
+                StyleClasses = { "CrewManifestGender" }
+            };
+            gender.SetMessage(Loc.GetString("gender-display", ("gender", entry.Gender)));
+
+            nameContainer.AddChild(name);
+            nameContainer.AddChild(gender);
+            // Delta-V - end of name and pronoun container
 
             var titleContainer = new BoxContainer()
             {
                 Orientation = LayoutOrientation.Horizontal,
-                HorizontalExpand = true
+                HorizontalExpand = true,
+                SizeFlagsStretchRatio = 1, // Delta-V
             };
 
             var title = new RichTextLabel();
@@ -69,8 +105,12 @@ public sealed class CrewManifestSection : BoxContainer
                 titleContainer.AddChild(title);
             }
 
-            gridContainer.AddChild(name);
-            gridContainer.AddChild(titleContainer);
+            // Delta-V - grid was replaced with two BoxContainer columns
+            //gridContainer.AddChild(name);
+            //gridContainer.AddChild(titleContainer);
+            namesContainer.AddChild(nameContainer);
+            titlesContainer.AddChild(titleContainer);
+            // Delta-V - end of grid container change
         }
     }
 }

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -172,7 +172,7 @@ namespace Content.Client.Stylesheets
         public const string ClassHighDivider = "HighDivider";
         public const string ClassLowDivider = "LowDivider";
         public const string ClassAngleRect = "AngleRect";
-
+        public const string StyleClassCrewManifestGender = "CrewManifestGender"; //Delta-V - Manifest pronouns
 
         public override Stylesheet Stylesheet { get; }
 
@@ -1235,6 +1235,13 @@ namespace Content.Client.Stylesheets
                     .Class(StyleClassItemStatusNotHeld)
                     .Prop("font", notoSansItalic10)
                     .Prop("font-color", ItemStatusNotHeldColor),
+
+                // Delta-V Start - Box - add style for pronouns on the crew manifest
+                Element<RichTextLabel>()
+                    .Class(StyleClassCrewManifestGender)
+                    .Prop("font", notoSansItalic10)
+                    .Prop("font-style", "italic"),
+                // Delta-V End - Box - add style for pronouns on the crew manifest
 
                 Element<RichTextLabel>()
                     .Class(StyleClassItemStatus)

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -229,7 +229,7 @@ public sealed class CrewManifestSystem : EntitySystem
         foreach (var recordObject in iter)
         {
             var record = recordObject.Item2;
-            var entry = new CrewManifestEntry(record.Name, record.JobTitle, record.JobIcon, record.JobPrototype);
+            var entry = new CrewManifestEntry(record.Name, record.Gender.ToString().ToLowerInvariant(), record.JobTitle, record.JobIcon, record.JobPrototype); // Box - adds record.Gender for pronouns
 
             _prototypeManager.TryIndex(record.JobPrototype, out JobPrototype? job);
             entriesSort.Add((job, entry));

--- a/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
+++ b/Content.Shared/CrewManifest/SharedCrewManifestSystem.cs
@@ -47,15 +47,19 @@ public sealed class CrewManifestEntry
 {
     public string Name { get; }
 
+    public string Gender { get; } // Delta-V: Added gender to crew manifest
+
     public string JobTitle { get; }
 
     public string JobIcon { get; }
 
     public string JobPrototype { get; }
 
-    public CrewManifestEntry(string name, string jobTitle, string jobIcon, string jobPrototype)
+    public CrewManifestEntry(string name, string gender, string jobTitle, string jobIcon, string jobPrototype) // Delta-v - Box - adds gender to string
+
     {
         Name = name;
+        Gender = gender; // Delta-V: Added gender to crew manifest
         JobTitle = jobTitle;
         JobIcon = jobIcon;
         JobPrototype = jobPrototype;

--- a/Resources/Locale/en-US/_DV/gender.ftl
+++ b/Resources/Locale/en-US/_DV/gender.ftl
@@ -1,0 +1,6 @@
+gender-display = ({$gender ->
+    [male] He / Him
+    [female] She / Her
+    [neuter] It / It
+    *[other] They / Them
+})


### PR DESCRIPTION
## About the PR
out here straight manifesting (my pronouns).

Ports content from a starcup PR, which in turn is lifted from DV.
github.com/teamstarcup/starcup/pull/3/

## Why / Balance
Helps clear up confusion on how to address a character if youre not close enough to shift click them.

## Technical details
-multiple lines of code added to Content.Client/CrewManifest/UI/CrewManifestSection.cs to adjust the manifest to support longer text
-Content.Client/Stylesheets/StyleNano.cs adds new fields to the stylesheet used for the manifest
-Content.Server/CrewManifest/CrewManifestSystem.cs adds a gender field to the manifest string
-Content.Shared/CrewManifest/SharedCrewManifestSystem.cs ditto the above.
-Resources/Locale/en-US/_DV/gender.ftl adds an ftl under DV namespace to assign pronouns associated with the various gender strings that exist in game.

## Media

<img width="562" height="177" alt="Untitled" src="https://github.com/user-attachments/assets/f6555c89-0308-4245-a50f-fbf164b15354" />
<img width="1159" height="438" alt="Untitled2" src="https://github.com/user-attachments/assets/64910fcb-9545-4eb9-bb5d-e47988af897e" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**

:cl:
- add: Adds pronouns to the manifest, both in the PDA and in the lobby.
