### PR TITLE
Troublemaker Phase 1c - New Kits + Rework of some old kits

### DIFF
--- a/Resources/Locale/en-US/_Box/tools/troublemaker-smuggling-case.ftl
+++ b/Resources/Locale/en-US/_Box/tools/troublemaker-smuggling-case.ftl
@@ -49,7 +49,7 @@ troublemaker-cheater-kit-description = Truth is, the game was rigged from the st
  a fake and real cap gun, a cybersun pen, and a deck of cards.
 
 troublemaker-syndi-kit-name = Off-Duty Syndicate Kit
-troublemaker-syndi-kit-description = For those who cant let a contract pass them by.
+troublemaker-syndi-kit-description = For those who can't let a contract pass them by.
  Contains a Suspicious Toolbox, a Chameleon Projector,
  an Armor-Piercing Python, E-pen, and a Business Card.
 

--- a/Resources/Locale/en-US/_Box/tools/troublemaker-smuggling-case.ftl
+++ b/Resources/Locale/en-US/_Box/tools/troublemaker-smuggling-case.ftl
@@ -3,9 +3,7 @@ troublemaker-window-description = What tools did you bring with you?
 
 troublemaker-spaceasshole-kit-name = Demolitionist Kit
 troublemaker-spaceasshole-kit-description = A kit for when you just need to watch your workplace burn.
- Contains a coat, some flash-resistant glasses,
- a sledgehammer, 2 seismic charges,
- and a seismic charge blueprint for if your rage isnt satisfied by the first two.
+ Contains a coat, a sledgehammer, and 3 seismic charges.
 
 troublemaker-phantomthief-kit-name = Dashing Rogue Kit
 troublemaker-phantomthief-kit-description = Style, elegance, and stealth are your tools. Leave an impression.
@@ -42,10 +40,40 @@ troublemaker-whistleblower-kit-description = Secrets and scandals are your domai
 
 troublemaker-arsonist-kit-name = Arsonist Kit
 troublemaker-arsonist-kit-description = Some people just want to watch the workplace burn.
- Contains a bandana, a fireaxe,
- and 3 fire bombs with random fuse times.
+ Contains a bandana, a box containing a random lighter,
+ and 4 fire bombs with random fuse times.
 
 troublemaker-cheater-kit-name = Cheater Kit
 troublemaker-cheater-kit-description = Truth is, the game was rigged from the start.
  Contains rigged boxing gloves (blue), real boxing gloves (red),
  a fake and real cap gun, a cybersun pen, and a deck of cards.
+
+troublemaker-syndi-kit-name = Off-Duty Syndicate Kit
+troublemaker-syndi-kit-description = For those who cant let a contract pass them by.
+ Contains a Suspicious Toolbox, a Chameleon Projector,
+ an Armor-Piercing Python, E-pen, and a Business Card.
+
+troublemaker-escape-kit-name = Escapist Kit
+troublemaker-escape-kit-description = Now you see me...
+ Contains a freedom, EMP, and Scram implant,
+ 2 15u doses of Ephedrine and a pair of skates.
+
+troublemaker-bomb-kit-name = Ultimate Distraction Kit
+troublemaker-bomb-kit-description = Not much to say about this one.
+ You need a distraction. Whats more distracting than a fake bomb?
+
+troublemaker-riot-kit-name = Rioter Kit
+troublemaker-riot-kit-description = You've been around the block and lived to tell the tale.
+ Contains a baseball bat, a gas mask to hide your face, a radio jammer,
+ flash resistant sunglasses, 2 tear gas grenades,
+ a spraypainter and 2 refills of paint.
+
+troublemaker-chameleon-kit-name = Social Butterfly Kit
+troublemaker-chameleon-kit-description = Be anyone, go anywhere.
+ Contains a full chameleon kit, an Agent ID, an approved Rubber Stamp,
+ a secure briefcase, dna scrambler implant, and a luxury pen.
+
+troublemaker-merc-kit-name = Mercenary Kit
+troublemaker-merc-kit-description = Equipment saved for one last job.
+ Contains a set of mercenary gloves, helmet, gas mask, boots, and webbing.
+ Lastly, an old heirloom - a Mosin.

--- a/Resources/Prototypes/_Box/Catalog/troublemaker-uplink-catalog.yml
+++ b/Resources/Prototypes/_Box/Catalog/troublemaker-uplink-catalog.yml
@@ -7,11 +7,10 @@
     state: icon
   content:
   - ClothingOuterCoatSpaceAsshole
-  - ClothingEyesGlassesSunglasses
   - Sledgehammer
   - SeismicCharge
   - SeismicCharge
-  - BlueprintSeismicCharge
+  - SeismicCharge
 
 - type: thiefBackpackSet
   id: TroublemakerPhantomThiefKit
@@ -101,7 +100,8 @@
     state: base
   content:
   - ClothingMaskBandBlack
-  - FireAxe
+  - MysteryLighterBox
+  - FireBomb
   - FireBomb
   - FireBomb
   - FireBomb
@@ -130,9 +130,95 @@
     state: deck_black_full
   content:
   - ClothingHandsGlovesBoxingRigged
-  - ClothingHandsGlovesBoxingRigged
+  - ClothingHandsGlovesBoxingRed
   - RevolverCapGun
   - RevolverCapGunFake
   - CyberPen #To Do - add a generic non syndi version
   - CardBoxBlack
 
+- type: thiefBackpackSet
+  id: TroublemakerSyndiKit
+  name: troublemaker-syndi-kit-name
+  description: troublemaker-syndi-kit-description
+  sprite:
+      sprite: Objects/Misc/bureaucracy.rsi
+      state: syndicate_card
+  content:
+  - ToolboxSyndicateFilled
+  - ChameleonProjector
+  - WeaponRevolverPythonAP
+  - EnergyDagger
+  - SyndicateBusinessCard
+
+- type: thiefBackpackSet
+  id: TroublemakerEscapeKit
+  name: troublemaker-escape-kit-name
+  description: troublemaker-escape-kit-description
+  sprite:
+    sprite: Objects/Misc/handcuffs.rsi
+    state: handcuff
+  content:
+  - FreedomImplanter
+  - EmpImplanter
+  - ScramImplanter
+  - SyringeEphedrine
+  - SyringeEphedrine
+  - ClothingShoesSkates
+
+- type: thiefBackpackSet
+  id: TroublemakerBombKit
+  name: troublemaker-bomb-kit-name
+  description: troublemaker-bomb-kit-description
+  sprite:
+    sprite: Structures/Machines/bomb.rsi
+    state: training-bomb
+  content:
+  - SyndicateBombFake
+
+- type: thiefBackpackSet
+  id: TroublemakerRiotKit
+  name: troublemaker-riot-kit-name
+  description: troublemaker-riot-kit-description
+  sprite:
+    sprite: Objects/Weapons/Melee/baseball_bat.rsi
+    state: icon
+  content:
+  - BaseBallBat
+  - ClothingMaskGas
+  - RadioJammer
+  - ClothingEyesGlassesSunglasses
+  - TearGasGrenade
+  - TearGasGrenade
+  - SprayPainterAmmo
+  - SprayPainterAmmo
+  - SprayPainter
+
+- type: thiefBackpackSet
+  id: TroublemakerChameleonKit
+  name: troublemaker-chameleon-kit-name
+  description: troublemaker-chameleon-kit-description
+  sprite:
+    sprite:  Objects/Misc/pens.rsi
+    state: luxury_pen
+  content:
+  - ClothingBackpackChameleonFill
+  - AgentIDCard
+  - RubberStampApproved
+  - BriefcaseSecure
+  - DnaScramblerImplanter
+  - LuxuryPen
+
+- type: thiefBackpackSet
+  id: TroublemakerMercKit
+  name: troublemaker-merc-kit-name
+  description: troublemaker-merc-kit-description
+  sprite:
+    sprite:  Clothing/Mask/merc.rsi
+    state: icon
+  content:
+  - ClothingHeadHelmetMerc
+  - ClothingMaskGasMerc
+  - ClothingShoesBootsMercFilled
+  - ClothingHandsMercGlovesCombat
+  - ClothingBeltMercWebbing
+  - WeaponSniperMosin

--- a/Resources/Prototypes/_Box/Entities/Objects/Specific/Troublemaker.yml
+++ b/Resources/Prototypes/_Box/Entities/Objects/Specific/Troublemaker.yml
@@ -19,4 +19,10 @@
     - TroublemakerWhistleblowerKit
     - TroublemakerArsonistKit
     - TroublemakerCheaterKit
+    - TroublemakerSyndiKit
+    - TroublemakerEscapeKit
+    - TroublemakerBombKit
+    - TroublemakerRiotKit
+    - TroublemakerChameleonKit
+    - TroublemakerMercKit
     spawnedStoragePrototype: ClothingBackpackSatchelSmugglerUnanchored


### PR DESCRIPTION
## About the PR
Adds a few new kits to Troublemakers, and makes some minor tweaks to old ones.

Old Kits:
-Demolitionist lost the flashproof sunglasses and the blueprint, replaced with another seismic charge.
-Arsonist lost the fireaxe, gained another firebomb and a random lighter box.
-Fixed a mistake in the gambler kit where both gloves were rigged instead of just one (oops).

New Kits:
-Off-duty syndicate: Susbox, Chameleon Projector, Python (AP), E-Pen, Syndi Business Card.
-Escapist: Freedom, EMP, Scram implants, 2x15u ephedrine syringes, rollerskates.
-Ultimate Distraction: a single fake hardbomb.
-Riot: Baseball bat, gas mask, radiojammer, sunglasses, 2 tear gas grenades, spraypainter and 2x paint.
-Social Butterfly: Chameleon Kit, Agent ID, Approved Stamp, Secure Briefcase, DNA Scrambler Implant, Luxury Pen.
-Mercenary: Merc helmet, Gas Mask, Boots with a kurkri, combat gloves, chest webbing, and a mosin.

## Why / Balance
-More kits allow for more expression in how you want to make trouble.
-Some of the old kits were a tad problematic, and were requested to be tweaked on consensus of the admin team.

## Technical details
-edits kit description in: Resources/Locale/en-US/_Box/tools/troublemaker-smuggling-case.ftl
-edits contents in: Resources/Prototypes/_Box/Catalog/troublemaker-uplink-catalog.yml
-adds new entries to the uplink here: Resources/Prototypes/_Box/Entities/Objects/Specific/Troublemaker.yml

## Media
<img width="694" height="533" alt="screenshot1" src="https://github.com/user-attachments/assets/e4353e56-398b-451b-98ba-6373eef03c1c" />
<img width="675" height="535" alt="screenshot2" src="https://github.com/user-attachments/assets/b5359892-edc6-46df-9385-37f0e82e6249" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- add: Adds 6 new kits to the Troublemaker, bringing the total to 15.
- tweak: Some Troublemaker kits have had their content adjusted.
- fix: the Cheater troublemaker kit now properly spawns with one rigged, one normal set of boxing gloves instead of two rigged.

