### PR TITLE
Removes Landmines from Debris Spawning

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -411,13 +411,15 @@
       children:
       - id: MobCarpSalvage
         weight: 2
-      - !type:AllSelector
-        weight: 1
-        children:
-        - id: LandMineExplosive
-        - !type:NestedSelector # what's that thing underneath the scrap?
-          prob: 0.33
-          tableId: SalvageScrapSpawnerCommon
+    #Box Change Start - Removes landmines from spawning pool
+    #  - !type:AllSelector
+    #    weight: 1
+    #    children:
+    #    - id: LandMineExplosive
+    #    - !type:NestedSelector # what's that thing underneath the scrap?
+    #      prob: 0.33
+    #      tableId: SalvageScrapSpawnerCommon
+    #Box Change Start - Removes landmines from spawning pool
     - !type:GroupSelector # scary monsters
       weight: 5
       children:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -419,7 +419,7 @@
     #    - !type:NestedSelector # what's that thing underneath the scrap?
     #      prob: 0.33
     #      tableId: SalvageScrapSpawnerCommon
-    #Box Change Start - Removes landmines from spawning pool
+    #Box Change End - Removes landmines from spawning pool
     - !type:GroupSelector # scary monsters
       weight: 5
       children:


### PR DESCRIPTION
## About the PR
Removes landmines from the debris spawner.

## Why / Balance
I'm personally for keeping them, I think blowing up here and there is good character building. 

However, I accept that its not healthy for the longterm, and half the staff team are just hucking people back to the station after they blow up anyway. So no point them being here. And the right click shuffle on every bit of scrap is a pain on the wrist.

So long, and thanks for all the fish landmines.

to test this I spawned in 3 debris and found no landmines. I also spammed salvage loot spawners about 50 times and got no landmines. So we're all good here.

## Technical details
- comments out a codeblock in Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml

## Media
<img width="1086" height="801" alt="Untitled" src="https://github.com/user-attachments/assets/dc6ccb04-b45c-46a4-8710-86eb300fb3b4" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- remove: Landmines no longer spawn on debris.


