### PR TITLE
Removes the Syndicate Dropship Salvage Ruin

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -77,7 +77,7 @@
           - /Maps/Ruins/hydro_outpost.yml
           - /Maps/Ruins/old_ai_sat.yml
           - /Maps/Ruins/ruined_prison_ship.yml
-          - /Maps/Ruins/syndicate_dropship.yml
+#         - /Maps/Ruins/syndicate_dropship.yml # Box Change - removes dropship ruin
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
           - /Maps/Ruins/wrecklaimer.yml


### PR DESCRIPTION
## About the PR
This PR prevents the spawning of the Syndicate Dropship salvage ruin.

## Why / Balance
The Dropship is the epitomy of unhealthy salvage design. It causes constant headaches for the admin team everytime it spawns.

1. Its loaded with contraband. in total the contraband on board adds up to around 12TC! (over half an agents entire budget!). A full chameleon kit (4tc), a viper pistol (3tc), a syndicate ID card (1tc), 2x chest rig (1tc), and the contraband contents of a robust toolbox (mask and gloves) (2tc).
2. It contains several high-value items such as the riot mask, crew monitoring console, and shuttle APUs.
3. It has 2 turrets, which normally lead to round removal without a chance to react.
4. Its a fully working shuttle right off the bat, which leads to salvage fucking off for the rest of the round and flaunting their contraband.

## Technical details
-removes one line in Resources/Prototypes/Entities/Stations/base.yml via commenting out

## Media
<img width="947" height="937" alt="image" src="https://github.com/user-attachments/assets/d08f7bdf-5f88-4271-ace3-44c8df62a0ae" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- remove: The Syndicate Dropship ruin has been removed.


