### PR TITLE
[Bugfix] Fixes cargo/nanotask formatting errors introduced during engine upgrade

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -119,9 +119,11 @@ public sealed partial class CargoSystem
         label.Id = bounty.Id;
         label.AssociatedStationId = stationId;
         var msg = new FormattedMessage();
-        msg.AddText(Loc.GetString("bounty-manifest-header", ("id", bounty.Id)));
+    /// msg.AddText(Loc.GetString("bounty-manifest-header", ("id", bounty.Id))); Box Change - Fixes Bounty Print Formatting
+        msg.AddMarkupOrThrow(Loc.GetString("bounty-manifest-header", ("id", bounty.Id))); /// Box Change - fixes bounty print formatting
         msg.PushNewline();
-        msg.AddText(Loc.GetString("bounty-manifest-list-start"));
+    /// msg.AddText(Loc.GetString("bounty-manifest-list-start")); Box Change - Fixes bounty print formatting
+        msg.AddMarkupOrThrow(Loc.GetString("bounty-manifest-list-start")); /// Box Change - fixes bounty print formatting
         msg.PushNewline();
         foreach (var entry in prototype.Entries)
         {

--- a/Content.Server/CartridgeLoader/Cartridges/NanoTaskCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/NanoTaskCartridgeSystem.cs
@@ -77,11 +77,14 @@ public sealed class NanoTaskCartridgeSystem : SharedNanoTaskCartridgeSystem
 
         printed.Task = item;
         var msg = new FormattedMessage();
-        msg.AddText(Loc.GetString("nano-task-printed-description", ("description", item.Description)));
+    /// msg.AddText(Loc.GetString("nano-task-printed-description", ("description", item.Description))); /// Box Change - Fixes Nanochat formatting
+        msg.AddMarkupOrThrow(Loc.GetString("nano-task-printed-description", ("description", FormattedMessage.EscapeText(item.Description)))); /// Box Change - Fixes nanochat formatting
         msg.PushNewline();
-        msg.AddText(Loc.GetString("nano-task-printed-requester", ("requester", item.TaskIsFor)));
+    /// msg.AddText(Loc.GetString("nano-task-printed-requester", ("requester", item.TaskIsFor)));
+        msg.AddMarkupOrThrow(Loc.GetString("nano-task-printed-requester", ("requester", FormattedMessage.EscapeText(item.TaskIsFor)))); /// Box Change - fixes nanochat formatting
         msg.PushNewline();
-        msg.AddText(item.Priority switch {
+    /// msg.AddText(item.Priority switch { /// Box Change - fixes nanochat formatting
+        msg.AddMarkupOrThrow(item.Priority switch {
             NanoTaskPriority.High => Loc.GetString("nano-task-printed-high-priority"),
             NanoTaskPriority.Medium => Loc.GetString("nano-task-printed-medium-priority"),
             NanoTaskPriority.Low => Loc.GetString("nano-task-printed-low-priority"),


### PR DESCRIPTION

## About the PR
what it says on the tin.
manual port of: https://github.com/space-wizards/space-station-14/pull/42030
## Why / Balance
bugfix.
was caused by the strings using msg.AddText instead of msg.AddMarkupOrThrow.

## Technical details
updates strings in Content.Server/Cargo/Systems/CargoSystem.Bounty.cs and Content.Server/CartridgeLoader/Cartridges/NanoTaskCartridgeSystem.cs

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**

:cl:
- fix: Nanotasks and Bounty slips no longer show the markup formatting and now look normal.
