### PR TITLE
[Bugfix] Fixes Spelling Mistake in Synthanol Flavor Text Popups

### DIFF
--- a/Resources/Locale/en-US/_Box/reagents/synthanol.ftl
+++ b/Resources/Locale/en-US/_Box/reagents/synthanol.ftl
@@ -1,4 +1,4 @@
 synthanol-effect-buzz = You feel a temporary buzz
-synthanol-effect-courageous = You feel temporarily corageous
+synthanol-effect-courageous = You feel temporarily courageous
 synthanol-effect-no-anxiety = You feel your anxieties temporarily fade
 synthanol-effect-social = It feels temporarily easier to socialize


### PR DESCRIPTION
## About the PR
Spelling mistake in the .ftl for synthanol effect popups.
You feel temporarily corageous --> You feel temporarily courageous

## Why / Balance
bugfix

## Technical details
changes a single word in Resources/Locale/en-US/_Box/reagents/synthanol.ftl

## Media
<img width="276" height="177" alt="image" src="https://github.com/user-attachments/assets/4d8fd328-3821-4d75-9fc6-8d4ca455428b" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Fixes a spelling mistake in certain synthanol flavortext popups.
