### PR TITLE
[FIX] Mute Characters Can Blink

### DIFF
--- a/Resources/Locale/en-US/chat/ui/emote-menu.ftl
+++ b/Resources/Locale/en-US/chat/ui/emote-menu.ftl
@@ -1,3 +1,5 @@
 emote-menu-category-general = General
 emote-menu-category-vocal = Vocal
-emote-menu-category-hands = Hands
+# Box Change Start - Hands --> Body
+emote-menu-category-hands = Body
+# Box Change End - Hands --> Body

--- a/Resources/Prototypes/_Impstation/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_Impstation/Voice/speech_emotes.yml
@@ -1,7 +1,7 @@
 - type: emote
   id: Blink
   name: chat-emote-name-blink
-  category: General
+  category: Hands #Box Change - General --> Hands - So mute characters can blink
   icon: _Impstation/Interface/Emotes/blink.png #imp
   chatMessages: ["chat-emote-msg-blink"]
   chatTriggers:


### PR DESCRIPTION
## About the PR
Small pr to make it so mute characters can blink.
Makes a small adjustment so that the "hands" category is renamed to "Body".

## Why / Balance
Mouth doesnt work
Look inside
Eyes no longer make noises

## Technical details
- updates FTL here Resources/Locale/en-US/chat/ui/emote-menu.ftl
- updates category from general to hands here: Resources/Prototypes/_Impstation/Voice/speech_emotes.yml 

## Media

https://github.com/user-attachments/assets/ba73a4c4-6481-4fd2-8e69-0a63471d45b6

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: the "hands" emote wheel category has been renamed to "body".
- fix: Mute characters can now use the sound part of the "blink" emote.

