### PR TITLE
hold-to-attack accessibility option

### DIFF
--- a/Content.Client/CombatMode/CombatModeIndicatorsOverlay.cs
+++ b/Content.Client/CombatMode/CombatModeIndicatorsOverlay.cs
@@ -4,10 +4,8 @@ using Content.Shared.Weapons.Ranged.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
-using Robust.Client.Serialization;
 using Robust.Client.UserInterface;
 using Robust.Shared.Enums;
-using Robust.Shared.Graphics;
 using Robust.Shared.Utility;
 
 namespace Content.Client.CombatMode;

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -15,8 +15,8 @@
                 <ui:OptionSlider Name="SpeechBubbleSpeakerOpacitySlider" Title="{Loc 'ui-options-speech-bubble-speaker-opacity'}" />
                 <ui:OptionSlider Name="SpeechBubbleBackgroundOpacitySlider" Title="{Loc 'ui-options-speech-bubble-background-opacity'}" />
                 <CheckBox Name="AutoFillHighlightsCheckBox" Text="{Loc 'ui-options-auto-fill-highlights'}" />
-                <ui:OptionColorSlider Name="HighlightsColorSlider" 
-                    Title="{Loc 'ui-options-highlights-color'}" 
+                <ui:OptionColorSlider Name="HighlightsColorSlider"
+                    Title="{Loc 'ui-options-highlights-color'}"
                     Example="{Loc 'ui-options-highlights-color-example'}"/>
                 <Label Text="{Loc 'ui-options-accessability-header-content'}"
                        StyleClasses="LabelKeyText"/>

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -36,12 +36,6 @@ namespace Content.Client.Options.UI.Tabs
 
         private readonly List<Action> _deferCommands = new();
 
-        private void HandleToggleUSQWERTYCheckbox(BaseButton.ButtonToggledEventArgs args)
-        {
-            _cfg.SetCVar(CVars.DisplayUSQWERTYHotkeys, args.Pressed);
-            _cfg.SaveToFile();
-        }
-
         private void InitToggleWalk()
         {
             if (_cfg.GetCVar(CCVars.ToggleWalk))
@@ -150,8 +144,23 @@ namespace Content.Client.Options.UI.Tabs
                 KeybindsContainer.AddChild(newCheckBox);
             }
 
+            void AddToggleCvarCheckBox(string checkBoxName, CVarDef<bool> cvar)
+            {
+                CheckBox newCheckBox = new CheckBox() { Text = Loc.GetString(checkBoxName) };
+                newCheckBox.Pressed = _cfg.GetCVar(cvar);
+                newCheckBox.OnToggled += (e) =>
+                {
+                    _cfg.SetCVar(cvar, e.Pressed);
+                    _cfg.SaveToFile();
+                };
+
+                KeybindsContainer.AddChild(newCheckBox);
+            }
+
             AddHeader("ui-options-header-general");
-            AddCheckBox("ui-options-hotkey-keymap", _cfg.GetCVar(CVars.DisplayUSQWERTYHotkeys), HandleToggleUSQWERTYCheckbox);
+            AddToggleCvarCheckBox("ui-options-hotkey-keymap", CVars.DisplayUSQWERTYHotkeys);
+            AddToggleCvarCheckBox("ui-options-hold-to-attack-melee", CCVars.ControlHoldToAttackMelee);
+            AddToggleCvarCheckBox("ui-options-hold-to-attack-ranged", CCVars.ControlHoldToAttackRanged);
 
             AddHeader("ui-options-header-movement");
             AddButton(EngineKeyFunctions.MoveUp);

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Client.Gameplay;
+using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Effects;
 using Content.Shared.Hands.Components;
@@ -14,6 +15,7 @@ using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
 using Robust.Client.State;
+using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
@@ -31,6 +33,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private EntityQuery<TransformComponent> _xformQuery;
 
@@ -76,7 +79,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var useDown = _inputSystem.CmdStates.GetState(EngineKeyFunctions.Use);
         var altDown = _inputSystem.CmdStates.GetState(EngineKeyFunctions.UseSecondary);
 
-        if (weapon.AutoAttack || useDown != BoundKeyState.Down && altDown != BoundKeyState.Down)
+        if (weapon.AutoAttack || useDown != BoundKeyState.Down && altDown != BoundKeyState.Down || _cfg.GetCVar(CCVars.ControlHoldToAttackMelee))
         {
             if (weapon.Attacking)
             {

--- a/Content.Client/Weapons/Ranged/Components/MagazineVisualsComponent.cs
+++ b/Content.Client/Weapons/Ranged/Components/MagazineVisualsComponent.cs
@@ -11,17 +11,20 @@ public sealed partial class MagazineVisualsComponent : Component
     /// <summary>
     /// What RsiState we use.
     /// </summary>
-    [DataField("magState")] public string? MagState;
+    [DataField]
+    public string? MagState;
 
     /// <summary>
     /// How many steps there are
     /// </summary>
-    [DataField("steps")] public int MagSteps;
+    [DataField("steps")]
+    public int MagSteps;
 
     /// <summary>
     /// Should we hide when the count is 0
     /// </summary>
-    [DataField("zeroVisible")] public bool ZeroVisible;
+    [DataField]
+    public bool ZeroVisible;
 }
 
 public enum GunVisualLayers : byte

--- a/Content.Client/Weapons/Ranged/Components/SpentAmmoVisualsComponent.cs
+++ b/Content.Client/Weapons/Ranged/Components/SpentAmmoVisualsComponent.cs
@@ -8,9 +8,10 @@ public sealed partial class SpentAmmoVisualsComponent : Component
     /// <summary>
     /// Should we do "{_state}-spent" or just "spent"
     /// </summary>
-    [DataField("suffix")] public bool Suffix = true;
+    [DataField]
+    public bool Suffix = true;
 
-    [DataField("state")]
+    [DataField]
     public string State = "base";
 }
 

--- a/Content.Client/Weapons/Ranged/GunSpreadOverlay.cs
+++ b/Content.Client/Weapons/Ranged/GunSpreadOverlay.cs
@@ -48,7 +48,7 @@ public sealed class GunSpreadOverlay : Overlay
         if (mapPos.MapId == MapId.Nullspace)
             return;
 
-        if (!_guns.TryGetGun(player.Value, out var gunUid, out var gun))
+        if (!_guns.TryGetGun(player.Value, out var gun))
             return;
 
         var mouseScreenPos = _input.MouseScreenPosition;
@@ -58,12 +58,12 @@ public sealed class GunSpreadOverlay : Overlay
             return;
 
         // (☞ﾟヮﾟ)☞
-        var maxSpread = gun.MaxAngleModified;
-        var minSpread = gun.MinAngleModified;
-        var timeSinceLastFire = (_timing.CurTime - gun.NextFire).TotalSeconds;
-        var currentAngle = new Angle(MathHelper.Clamp(gun.CurrentAngle.Theta - gun.AngleDecayModified.Theta * timeSinceLastFire,
-            gun.MinAngleModified.Theta, gun.MaxAngleModified.Theta));
-        var direction = (mousePos.Position - mapPos.Position);
+        var maxSpread = gun.Comp.MaxAngleModified;
+        var minSpread = gun.Comp.MinAngleModified;
+        var timeSinceLastFire = (_timing.CurTime - gun.Comp.NextFire).TotalSeconds;
+        var currentAngle = new Angle(MathHelper.Clamp(gun.Comp.CurrentAngle.Theta - gun.Comp.AngleDecayModified.Theta * timeSinceLastFire,
+            gun.Comp.MinAngleModified.Theta, gun.Comp.MaxAngleModified.Theta));
+        var direction = mousePos.Position - mapPos.Position;
 
         worldHandle.DrawLine(mapPos.Position, mousePos.Position + direction, Color.Orange);
 

--- a/Content.Client/Weapons/Ranged/ItemStatus/BulletRender.cs
+++ b/Content.Client/Weapons/Ranged/ItemStatus/BulletRender.cs
@@ -41,7 +41,7 @@ public abstract class BaseBulletRenderer : Control
     {
         var countPerRow = Math.Min(Capacity, CountPerRow(availableSize.X));
 
-        var rows = Math.Min((int) MathF.Ceiling(Capacity / (float) countPerRow), Rows);
+        var rows = Math.Min((int)MathF.Ceiling(Capacity / (float)countPerRow), Rows);
 
         var height = _params.ItemHeight * rows + (_params.VerticalSeparation * rows - 1);
         var width = RowWidth(countPerRow);
@@ -110,7 +110,7 @@ public abstract class BaseBulletRenderer : Control
 
     private int CountPerRow(float width)
     {
-        return (int) ((width - _params.ItemWidth + _params.ItemSeparation) / _params.ItemSeparation);
+        return (int)((width - _params.ItemWidth + _params.ItemSeparation) / _params.ItemSeparation);
     }
 
     private int RowWidth(int count)

--- a/Content.Client/Weapons/Ranged/Systems/FlyBySoundSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/FlyBySoundSystem.cs
@@ -2,10 +2,8 @@ using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Client.Player;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Events;
-using Robust.Shared.Player;
 using Robust.Shared.Random;
 
 namespace Content.Client.Weapons.Ranged.Systems;
@@ -22,26 +20,26 @@ public sealed class FlyBySoundSystem : SharedFlyBySoundSystem
         SubscribeLocalEvent<FlyBySoundComponent, StartCollideEvent>(OnCollide);
     }
 
-    private void OnCollide(EntityUid uid, FlyBySoundComponent component, ref StartCollideEvent args)
+    private void OnCollide(Entity<FlyBySoundComponent> ent, ref StartCollideEvent args)
     {
         var attachedEnt = _player.LocalEntity;
 
         // If it's not our ent or we shot it.
         if (attachedEnt == null ||
             args.OtherEntity != attachedEnt ||
-            TryComp<ProjectileComponent>(uid, out var projectile) &&
+            TryComp<ProjectileComponent>(ent, out var projectile) &&
             projectile.Shooter == attachedEnt)
         {
             return;
         }
 
         if (args.OurFixtureId != FlyByFixture ||
-            !_random.Prob(component.Prob))
+            !_random.Prob(ent.Comp.Prob))
         {
             return;
         }
 
         // Play attached to our entity because the projectile may immediately delete or the likes.
-        _audio.PlayPredicted(component.Sound, attachedEnt.Value, attachedEnt.Value);
+        _audio.PlayPredicted(ent.Comp.Sound, attachedEnt.Value, attachedEnt.Value);
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.AmmoCounter.cs
@@ -14,12 +14,12 @@ namespace Content.Client.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
-    private void OnAmmoCounterCollect(EntityUid uid, AmmoCounterComponent component, ItemStatusCollectMessage args)
+    private void OnAmmoCounterCollect(Entity<AmmoCounterComponent> ent, ref ItemStatusCollectMessage args)
     {
-        RefreshControl(uid, component);
+        RefreshControl(ent);
 
-        if (component.Control != null)
-            args.Controls.Add(component.Control);
+        if (ent.Comp.Control != null)
+            args.Controls.Add(ent.Comp.Control);
     }
 
     /// <summary>
@@ -27,35 +27,32 @@ public sealed partial class GunSystem
     /// </summary>
     /// <param name="uid"></param>
     /// <param name="component"></param>
-    private void RefreshControl(EntityUid uid, AmmoCounterComponent? component = null)
+    private void RefreshControl(Entity<AmmoCounterComponent> ent)
     {
-        if (!Resolve(uid, ref component, false))
-            return;
-
-        component.Control?.Dispose();
-        component.Control = null;
+        ent.Comp.Control?.Dispose();
+        ent.Comp.Control = null;
 
         var ev = new AmmoCounterControlEvent();
-        RaiseLocalEvent(uid, ev, false);
+        RaiseLocalEvent(ent, ev, false);
 
         // Fallback to default if none specified
         ev.Control ??= new DefaultStatusControl();
 
-        component.Control = ev.Control;
-        UpdateAmmoCount(uid, component);
+        ent.Comp.Control = ev.Control;
+        UpdateAmmoCount(ent);
     }
 
-    private void UpdateAmmoCount(EntityUid uid, AmmoCounterComponent component)
+    private void UpdateAmmoCount(Entity<AmmoCounterComponent> ent)
     {
-        if (component.Control == null)
+        if (ent.Comp.Control == null)
             return;
 
         var ev = new UpdateAmmoCounterEvent()
         {
-            Control = component.Control
+            Control = ent.Comp.Control
         };
 
-        RaiseLocalEvent(uid, ev, false);
+        RaiseLocalEvent(ent, ev, false);
     }
 
     protected override void UpdateAmmoCount(EntityUid uid, bool prediction = true)
@@ -68,7 +65,7 @@ public sealed partial class GunSystem
             return;
         }
 
-        UpdateAmmoCount(uid, clientComp);
+        UpdateAmmoCount((uid, clientComp));
     }
 
     /// <summary>

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -12,41 +12,41 @@ public sealed partial class GunSystem
         SubscribeLocalEvent<BallisticAmmoProviderComponent, UpdateAmmoCounterEvent>(OnBallisticAmmoCount);
     }
 
-    private void OnBallisticAmmoCount(EntityUid uid, BallisticAmmoProviderComponent component, UpdateAmmoCounterEvent args)
+    private void OnBallisticAmmoCount(Entity<BallisticAmmoProviderComponent> ent, ref UpdateAmmoCounterEvent args)
     {
         if (args.Control is DefaultStatusControl control)
         {
-            control.Update(GetBallisticShots(component), component.Capacity);
+            control.Update(GetBallisticShots(ent.Comp), ent.Comp.Capacity);
         }
     }
 
-    protected override void Cycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates)
+    protected override void Cycle(Entity<BallisticAmmoProviderComponent> ent, MapCoordinates coordinates)
     {
         if (!Timing.IsFirstTimePredicted)
             return;
 
-        EntityUid? ent = null;
+        EntityUid? ammoEnt = null;
 
         // TODO: Combine with TakeAmmo
-        if (component.Entities.Count > 0)
+        if (ent.Comp.Entities.Count > 0)
         {
-            var existing = component.Entities[^1];
-            component.Entities.RemoveAt(component.Entities.Count - 1);
+            var existing = ent.Comp.Entities[^1];
+            ent.Comp.Entities.RemoveAt(ent.Comp.Entities.Count - 1);
 
-            Containers.Remove(existing, component.Container);
+            Containers.Remove(existing, ent.Comp.Container);
             EnsureShootable(existing);
         }
-        else if (component.UnspawnedCount > 0)
+        else if (ent.Comp.UnspawnedCount > 0)
         {
-            component.UnspawnedCount--;
-            ent = Spawn(component.Proto, coordinates);
-            EnsureShootable(ent.Value);
+            ent.Comp.UnspawnedCount--;
+            ammoEnt = Spawn(ent.Comp.Proto, coordinates);
+            EnsureShootable(ammoEnt.Value);
         }
 
-        if (ent != null && IsClientSide(ent.Value))
-            Del(ent.Value);
+        if (ammoEnt != null && IsClientSide(ammoEnt.Value))
+            Del(ammoEnt.Value);
 
         var cycledEvent = new GunCycledEvent();
-        RaiseLocalEvent(uid, ref cycledEvent);
+        RaiseLocalEvent(ent, ref cycledEvent);
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.BasicEntity.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.BasicEntity.cs
@@ -10,11 +10,11 @@ public partial class GunSystem
         SubscribeLocalEvent<BasicEntityAmmoProviderComponent, UpdateAmmoCounterEvent>(OnBasicEntityAmmoCount);
     }
 
-    private void OnBasicEntityAmmoCount(EntityUid uid, BasicEntityAmmoProviderComponent component, UpdateAmmoCounterEvent args)
+    private void OnBasicEntityAmmoCount(Entity<BasicEntityAmmoProviderComponent> ent, ref UpdateAmmoCounterEvent args)
     {
-        if (args.Control is DefaultStatusControl control && component.Count != null && component.Capacity != null)
+        if (args.Control is DefaultStatusControl control && ent.Comp.Count != null && ent.Comp.Capacity != null)
         {
-            control.Update(component.Count.Value, component.Capacity.Value);
+            control.Update(ent.Comp.Count.Value, ent.Comp.Capacity.Value);
         }
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
@@ -18,11 +18,11 @@ public sealed partial class GunSystem
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, AppearanceChangeEvent>(OnChamberMagazineAppearance);
     }
 
-    private void OnChamberMagazineAppearance(EntityUid uid, ChamberMagazineAmmoProviderComponent component, ref AppearanceChangeEvent args)
+    private void OnChamberMagazineAppearance(Entity<ChamberMagazineAmmoProviderComponent> ent, ref AppearanceChangeEvent args)
     {
         if (args.Sprite == null ||
-            !_sprite.LayerMapTryGet((uid, args.Sprite), GunVisualLayers.Base, out var boltLayer, false) ||
-            !Appearance.TryGetData(uid, AmmoVisuals.BoltClosed, out bool boltClosed))
+            !_sprite.LayerMapTryGet((ent, args.Sprite), GunVisualLayers.Base, out var boltLayer, false) ||
+            !Appearance.TryGetData(ent, AmmoVisuals.BoltClosed, out bool boltClosed))
         {
             return;
         }
@@ -30,11 +30,11 @@ public sealed partial class GunSystem
         // Maybe re-using base layer for this will bite me someday but screw you future sloth.
         if (boltClosed)
         {
-            _sprite.LayerSetRsiState((uid, args.Sprite), boltLayer, "base");
+            _sprite.LayerSetRsiState((ent, args.Sprite), boltLayer, "base");
         }
         else
         {
-            _sprite.LayerSetRsiState((uid, args.Sprite), boltLayer, "bolt-open");
+            _sprite.LayerSetRsiState((ent, args.Sprite), boltLayer, "bolt-open");
         }
     }
 
@@ -55,17 +55,17 @@ public sealed partial class GunSystem
         // to avoid 6-7 additional entity spawns.
     }
 
-    private void OnChamberMagazineCounter(EntityUid uid, ChamberMagazineAmmoProviderComponent component, AmmoCounterControlEvent args)
+    private void OnChamberMagazineCounter(Entity<ChamberMagazineAmmoProviderComponent> ent, ref AmmoCounterControlEvent args)
     {
         args.Control = new ChamberMagazineStatusControl();
     }
 
-    private void OnChamberMagazineAmmoUpdate(EntityUid uid, ChamberMagazineAmmoProviderComponent component, UpdateAmmoCounterEvent args)
+    private void OnChamberMagazineAmmoUpdate(Entity<ChamberMagazineAmmoProviderComponent> ent, ref UpdateAmmoCounterEvent args)
     {
         if (args.Control is not ChamberMagazineStatusControl control) return;
 
-        var chambered = GetChamberEntity(uid);
-        var magEntity = GetMagazineEntity(uid);
+        var chambered = GetChamberEntity(ent);
+        var magEntity = GetMagazineEntity(ent);
         var ammoCountEv = new GetAmmoCountEvent();
 
         if (magEntity != null)

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Magazine.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Magazine.cs
@@ -11,11 +11,11 @@ public sealed partial class GunSystem
         SubscribeLocalEvent<MagazineAmmoProviderComponent, AmmoCounterControlEvent>(OnMagazineControl);
     }
 
-    private void OnMagazineAmmoUpdate(EntityUid uid, MagazineAmmoProviderComponent component, UpdateAmmoCounterEvent args)
+    private void OnMagazineAmmoUpdate(Entity<MagazineAmmoProviderComponent> ent, ref UpdateAmmoCounterEvent args)
     {
-        var ent = GetMagazineEntity(uid);
+        var magEnt = GetMagazineEntity(ent);
 
-        if (ent == null)
+        if (magEnt == null)
         {
             if (args.Control is DefaultStatusControl control)
             {
@@ -25,14 +25,14 @@ public sealed partial class GunSystem
             return;
         }
 
-        RaiseLocalEvent(ent.Value, args, false);
+        RaiseLocalEvent(magEnt.Value, args, false);
     }
 
-    private void OnMagazineControl(EntityUid uid, MagazineAmmoProviderComponent component, AmmoCounterControlEvent args)
+    private void OnMagazineControl(Entity<MagazineAmmoProviderComponent> ent, ref AmmoCounterControlEvent args)
     {
-        var ent = GetMagazineEntity(uid);
-        if (ent == null)
+        var magEnt = GetMagazineEntity(ent);
+        if (magEnt == null)
             return;
-        RaiseLocalEvent(ent.Value, args, false);
+        RaiseLocalEvent(magEnt.Value, args, false);
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.MagazineVisuals.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.MagazineVisuals.cs
@@ -13,24 +13,24 @@ public sealed partial class GunSystem
         SubscribeLocalEvent<MagazineVisualsComponent, AppearanceChangeEvent>(OnMagazineVisualsChange);
     }
 
-    private void OnMagazineVisualsInit(EntityUid uid, MagazineVisualsComponent component, ComponentInit args)
+    private void OnMagazineVisualsInit(Entity<MagazineVisualsComponent> ent, ref ComponentInit args)
     {
-        if (!TryComp<SpriteComponent>(uid, out var sprite)) return;
+        if (!TryComp<SpriteComponent>(ent, out var sprite)) return;
 
-        if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.Mag, out _, false))
+        if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.Mag, out _, false))
         {
-            _sprite.LayerSetRsiState((uid, sprite), GunVisualLayers.Mag, $"{component.MagState}-{component.MagSteps - 1}");
-            _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.Mag, false);
+            _sprite.LayerSetRsiState((ent, sprite), GunVisualLayers.Mag, $"{ent.Comp.MagState}-{ent.Comp.MagSteps - 1}");
+            _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.Mag, false);
         }
 
-        if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.MagUnshaded, out _, false))
+        if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.MagUnshaded, out _, false))
         {
-            _sprite.LayerSetRsiState((uid, sprite), GunVisualLayers.MagUnshaded, $"{component.MagState}-unshaded-{component.MagSteps - 1}");
-            _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.MagUnshaded, false);
+            _sprite.LayerSetRsiState((ent, sprite), GunVisualLayers.MagUnshaded, $"{ent.Comp.MagState}-unshaded-{ent.Comp.MagSteps - 1}");
+            _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.MagUnshaded, false);
         }
     }
 
-    private void OnMagazineVisualsChange(EntityUid uid, MagazineVisualsComponent component, ref AppearanceChangeEvent args)
+    private void OnMagazineVisualsChange(Entity<MagazineVisualsComponent> ent, ref AppearanceChangeEvent args)
     {
         // tl;dr
         // 1.If no mag then hide it OR
@@ -45,53 +45,53 @@ public sealed partial class GunSystem
         {
             if (!args.AppearanceData.TryGetValue(AmmoVisuals.AmmoMax, out var capacity))
             {
-                capacity = component.MagSteps;
+                capacity = ent.Comp.MagSteps;
             }
 
             if (!args.AppearanceData.TryGetValue(AmmoVisuals.AmmoCount, out var current))
             {
-                current = component.MagSteps;
+                current = ent.Comp.MagSteps;
             }
 
-            var step = ContentHelpers.RoundToLevels((int)current, (int)capacity, component.MagSteps);
+            var step = ContentHelpers.RoundToLevels((int)current, (int)capacity, ent.Comp.MagSteps);
 
-            if (step == 0 && !component.ZeroVisible)
+            if (step == 0 && !ent.Comp.ZeroVisible)
             {
-                if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.Mag, out _, false))
+                if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.Mag, out _, false))
                 {
-                    _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.Mag, false);
+                    _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.Mag, false);
                 }
 
-                if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.MagUnshaded, out _, false))
+                if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.MagUnshaded, out _, false))
                 {
-                    _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.MagUnshaded, false);
+                    _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.MagUnshaded, false);
                 }
 
                 return;
             }
 
-            if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.Mag, out _, false))
+            if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.Mag, out _, false))
             {
-                _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.Mag, true);
-                _sprite.LayerSetRsiState((uid, sprite), GunVisualLayers.Mag, $"{component.MagState}-{step}");
+                _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.Mag, true);
+                _sprite.LayerSetRsiState((ent, sprite), GunVisualLayers.Mag, $"{ent.Comp.MagState}-{step}");
             }
 
-            if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.MagUnshaded, out _, false))
+            if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.MagUnshaded, out _, false))
             {
-                _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.MagUnshaded, true);
-                _sprite.LayerSetRsiState((uid, sprite), GunVisualLayers.MagUnshaded, $"{component.MagState}-unshaded-{step}");
+                _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.MagUnshaded, true);
+                _sprite.LayerSetRsiState((ent, sprite), GunVisualLayers.MagUnshaded, $"{ent.Comp.MagState}-unshaded-{step}");
             }
         }
         else
         {
-            if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.Mag, out _, false))
+            if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.Mag, out _, false))
             {
-                _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.Mag, false);
+                _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.Mag, false);
             }
 
-            if (_sprite.LayerMapTryGet((uid, sprite), GunVisualLayers.MagUnshaded, out _, false))
+            if (_sprite.LayerMapTryGet((ent, sprite), GunVisualLayers.MagUnshaded, out _, false))
             {
-                _sprite.LayerSetVisible((uid, sprite), GunVisualLayers.MagUnshaded, false);
+                _sprite.LayerSetVisible((ent, sprite), GunVisualLayers.MagUnshaded, false);
             }
         }
     }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Revolver.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Revolver.cs
@@ -14,25 +14,25 @@ public sealed partial class GunSystem
         SubscribeLocalEvent<RevolverAmmoProviderComponent, EntRemovedFromContainerMessage>(OnRevolverEntRemove);
     }
 
-    private void OnRevolverEntRemove(EntityUid uid, RevolverAmmoProviderComponent component, EntRemovedFromContainerMessage args)
+    private void OnRevolverEntRemove(Entity<RevolverAmmoProviderComponent> ent, ref EntRemovedFromContainerMessage args)
     {
         if (args.Container.ID != RevolverContainer)
             return;
 
-        // See ChamberMagazineAmmoProvider
+        // <See ChamberMagazineAmmoProvider>
         if (!IsClientSide(args.Entity))
             return;
 
         QueueDel(args.Entity);
     }
 
-    private void OnRevolverAmmoUpdate(EntityUid uid, RevolverAmmoProviderComponent component, UpdateAmmoCounterEvent args)
+    private void OnRevolverAmmoUpdate(Entity<RevolverAmmoProviderComponent> ent, ref UpdateAmmoCounterEvent args)
     {
         if (args.Control is not RevolverStatusControl control) return;
-        control.Update(component.CurrentIndex, component.Chambers);
+        control.Update(ent.Comp.CurrentIndex, ent.Comp.Chambers);
     }
 
-    private void OnRevolverCounter(EntityUid uid, RevolverAmmoProviderComponent component, AmmoCounterControlEvent args)
+    private void OnRevolverCounter(Entity<RevolverAmmoProviderComponent> ent, ref AmmoCounterControlEvent args)
     {
         args.Control = new RevolverStatusControl();
     }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
@@ -11,7 +11,7 @@ public sealed partial class GunSystem
         SubscribeLocalEvent<SpentAmmoVisualsComponent, AppearanceChangeEvent>(OnSpentAmmoAppearance);
     }
 
-    private void OnSpentAmmoAppearance(EntityUid uid, SpentAmmoVisualsComponent component, ref AppearanceChangeEvent args)
+    private void OnSpentAmmoAppearance(Entity<SpentAmmoVisualsComponent> ent, ref AppearanceChangeEvent args)
     {
         var sprite = args.Sprite;
         if (sprite == null) return;
@@ -21,15 +21,15 @@ public sealed partial class GunSystem
             return;
         }
 
-        var spent = (bool) varSpent;
+        var spent = (bool)varSpent;
         string state;
 
         if (spent)
-            state = component.Suffix ? $"{component.State}-spent" : "spent";
+            state = ent.Comp.Suffix ? $"{ent.Comp.State}-spent" : "spent";
         else
-            state = component.State;
+            state = ent.Comp.State;
 
-        _sprite.LayerSetRsiState((uid, sprite), AmmoVisualLayers.Base, state);
-        _sprite.RemoveLayer((uid, sprite), AmmoVisualLayers.Tip, false);
+        _sprite.LayerSetRsiState((ent, sprite), AmmoVisualLayers.Base, state);
+        _sprite.RemoveLayer((ent, sprite), AmmoVisualLayers.Tip, false);
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -31,13 +31,13 @@ namespace Content.Client.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem : SharedGunSystem
 {
+    [Dependency] private readonly AnimationPlayerSystem _animPlayer = default!;
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IStateManager _state = default!;
-    [Dependency] private readonly AnimationPlayerSystem _animPlayer = default!;
-    [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly SharedCameraRecoilSystem _recoil = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
@@ -167,29 +167,29 @@ public sealed partial class GunSystem : SharedGunSystem
 
         var entity = entityNull.Value;
 
-        if (!TryGetGun(entity, out var gunUid, out var gun))
+        if (!TryGetGun(entity, out var gun))
         {
             return;
         }
 
-        var useKey = gun.UseKey ? EngineKeyFunctions.Use : EngineKeyFunctions.UseSecondary;
+        var useKey = gun.Comp.UseKey ? EngineKeyFunctions.Use : EngineKeyFunctions.UseSecondary;
 
-        if (_inputSystem.CmdStates.GetState(useKey) != BoundKeyState.Down && !gun.BurstActivated)
+        if (_inputSystem.CmdStates.GetState(useKey) != BoundKeyState.Down && !gun.Comp.BurstActivated)
         {
-            if (gun.ShotCounter != 0)
-                RaisePredictiveEvent(new RequestStopShootEvent { Gun = GetNetEntity(gunUid) });
+            if (gun.Comp.ShotCounter != 0)
+                RaisePredictiveEvent(new RequestStopShootEvent { Gun = GetNetEntity(gun) });
             return;
         }
 
-        if (gun.NextFire > Timing.CurTime)
+        if (gun.Comp.NextFire > Timing.CurTime)
             return;
 
         var mousePos = _eyeManager.PixelToMap(_inputManager.MouseScreenPosition);
 
         if (mousePos.MapId == MapId.Nullspace)
         {
-            if (gun.ShotCounter != 0)
-                RaisePredictiveEvent(new RequestStopShootEvent { Gun = GetNetEntity(gunUid) });
+            if (gun.Comp.ShotCounter != 0)
+                RaisePredictiveEvent(new RequestStopShootEvent { Gun = GetNetEntity(gun) });
 
             return;
         }
@@ -207,11 +207,11 @@ public sealed partial class GunSystem : SharedGunSystem
         {
             Target = target,
             Coordinates = GetNetCoordinates(coordinates),
-            Gun = GetNetEntity(gunUid),
+            Gun = GetNetEntity(gun),
         });
     }
 
-    public override void Shoot(EntityUid gunUid, GunComponent gun, List<(EntityUid? Entity, IShootable Shootable)> ammo,
+    public override void Shoot(Entity<GunComponent> gun, List<(EntityUid? Entity, IShootable Shootable)> ammo,
         EntityCoordinates fromCoordinates, EntityCoordinates toCoordinates, out bool userImpulse, EntityUid? user = null, bool throwItems = false)
     {
         userImpulse = true;
@@ -226,7 +226,7 @@ public sealed partial class GunSystem : SharedGunSystem
         {
             if (throwItems)
             {
-                Recoil(user, direction, gun.CameraRecoilScalarModified);
+                Recoil(user, direction, gun.Comp.CameraRecoilScalarModified);
                 if (IsClientSide(ent!.Value))
                     Del(ent.Value);
                 else
@@ -241,9 +241,9 @@ public sealed partial class GunSystem : SharedGunSystem
                     if (!cartridge.Spent)
                     {
                         SetCartridgeSpent(ent!.Value, cartridge, true);
-                        MuzzleFlash(gunUid, cartridge, worldAngle, user);
-                        Audio.PlayPredicted(gun.SoundGunshotModified, gunUid, user);
-                        Recoil(user, direction, gun.CameraRecoilScalarModified);
+                        MuzzleFlash(gun, cartridge, worldAngle, user);
+                        Audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
+                        Recoil(user, direction, gun.Comp.CameraRecoilScalarModified);
                         // TODO: Can't predict entity deletions.
                         //if (cartridge.DeleteOnSpawn)
                         //    Del(cartridge.Owner);
@@ -251,7 +251,7 @@ public sealed partial class GunSystem : SharedGunSystem
                     else
                     {
                         userImpulse = false;
-                        Audio.PlayPredicted(gun.SoundEmpty, gunUid, user);
+                        Audio.PlayPredicted(gun.Comp.SoundEmpty, gun, user);
                     }
 
                     if (IsClientSide(ent!.Value))
@@ -259,17 +259,17 @@ public sealed partial class GunSystem : SharedGunSystem
 
                     break;
                 case AmmoComponent newAmmo:
-                    MuzzleFlash(gunUid, newAmmo, worldAngle, user);
-                    Audio.PlayPredicted(gun.SoundGunshotModified, gunUid, user);
-                    Recoil(user, direction, gun.CameraRecoilScalarModified);
+                    MuzzleFlash(gun, newAmmo, worldAngle, user);
+                    Audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
+                    Recoil(user, direction, gun.Comp.CameraRecoilScalarModified);
                     if (IsClientSide(ent!.Value))
                         Del(ent.Value);
                     else
                         RemoveShootable(ent.Value);
                     break;
                 case HitscanAmmoComponent:
-                    Audio.PlayPredicted(gun.SoundGunshotModified, gunUid, user);
-                    Recoil(user, direction, gun.CameraRecoilScalarModified);
+                    Audio.PlayPredicted(gun.Comp.SoundGunshotModified, gun, user);
+                    Recoil(user, direction, gun.Comp.CameraRecoilScalarModified);
                     break;
             }
         }
@@ -407,5 +407,5 @@ public sealed partial class GunSystem : SharedGunSystem
     }
 
     // TODO: Move RangedDamageSoundComponent to shared so this can be predicted.
-    public override void PlayImpactSound(EntityUid otherEntity, DamageSpecifier? modifiedDamage, SoundSpecifier? weaponSound, bool forceWeaponSound) {}
+    public override void PlayImpactSound(EntityUid otherEntity, DamageSpecifier? modifiedDamage, SoundSpecifier? weaponSound, bool forceWeaponSound) { }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -4,6 +4,7 @@ using Content.Client.Gameplay;
 using Content.Client.Items;
 using Content.Client.Weapons.Ranged.Components;
 using Content.Shared.Camera;
+using Content.Shared.CCVar;
 using Content.Shared.CombatMode;
 using Content.Shared.Damage;
 using Content.Shared.Weapons.Hitscan.Components;
@@ -19,6 +20,7 @@ using Robust.Client.Player;
 using Robust.Client.State;
 using Robust.Shared.Animations;
 using Robust.Shared.Audio;
+using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -38,6 +40,7 @@ public sealed partial class GunSystem : SharedGunSystem
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IStateManager _state = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly SharedCameraRecoilSystem _recoil = default!;
     [Dependency] private readonly SharedMapSystem _maps = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
@@ -203,11 +206,13 @@ public sealed partial class GunSystem : SharedGunSystem
 
         Log.Debug($"Sending shoot request tick {Timing.CurTick} / {Timing.CurTime}");
 
+
         RaisePredictiveEvent(new RequestShootEvent
         {
             Target = target,
             Coordinates = GetNetCoordinates(coordinates),
             Gun = GetNetEntity(gun),
+            Continuous = _cfg.GetCVar(CCVars.ControlHoldToAttackRanged),
         });
     }
 

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.Helpers.cs
@@ -478,11 +478,11 @@ public abstract partial class InteractionTest
         var wasInCombatMode = IsInCombatMode();
         await SetCombatMode(true);
 
-        Assert.That(SGun.TryGetGun(SPlayer, out var gunUid, out var gunComp), "Player was not holding a gun!");
+        Assert.That(SGun.TryGetGun(SPlayer, out var gun), "Player was not holding a gun!");
 
         await Server.WaitAssertion(() =>
         {
-            var success = SGun.AttemptShoot(SPlayer, gunUid, gunComp!, actualTarget);
+            var success = SGun.AttemptShoot(SPlayer, gun, actualTarget);
             if (assert)
                 Assert.That(success, "Gun failed to shoot.");
         });
@@ -517,11 +517,11 @@ public abstract partial class InteractionTest
         var wasInCombatMode = IsInCombatMode();
         await SetCombatMode(true);
 
-        Assert.That(SGun.TryGetGun(SPlayer, out var gunUid, out var gunComp), "Player was not holding a gun!");
+        Assert.That(SGun.TryGetGun(SPlayer, out var gun), "Player was not holding a gun!");
 
         await Server.WaitAssertion(() =>
         {
-            var success = SGun.AttemptShoot(SPlayer, gunUid, gunComp!, Position(actualTarget!.Value), ToServer(actualTarget));
+            var success = SGun.AttemptShoot(SPlayer, gun, Position(actualTarget!.Value), ToServer(actualTarget));
             if (assert)
                 Assert.That(success, "Gun failed to shoot.");
         });
@@ -839,7 +839,7 @@ public abstract partial class InteractionTest
     /// <param name="uid">The entity at which the events were directed</param>
     /// <param name="count">How many new events are expected</param>
     /// <param name="predicate">A predicate that can be used to filter the recorded events</param>
-    protected void AssertEvent<TEvent>(EntityUid? uid = null, int count = 1, Func<TEvent,bool>? predicate = null)
+    protected void AssertEvent<TEvent>(EntityUid? uid = null, int count = 1, Func<TEvent, bool>? predicate = null)
         where TEvent : notnull
     {
         Assert.That(GetEvents(uid, predicate).Count, Is.EqualTo(count));
@@ -872,7 +872,7 @@ public abstract partial class InteractionTest
         where TEvent : notnull
     {
         if (_listenerCache.TryGetValue(typeof(TEvent), out var listener))
-            return (TestListenerSystem<TEvent>) listener;
+            return (TestListenerSystem<TEvent>)listener;
 
         var type = Server.Resolve<IReflectionManager>().GetAllChildren<TestListenerSystem<TEvent>>().Single();
         if (!SEntMan.EntitySysManager.TryGetEntitySystem(type, out var systemObj))

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -773,7 +773,7 @@ public sealed partial class AdminVerbSystem
                             return;
 
                         _gun.SetBallisticUnspawned((args.Target, ballisticAmmo), result);
-                        _gun.UpdateBallisticAppearance(args.Target, ballisticAmmo);
+                        _gun.UpdateBallisticAppearance((args.Target, ballisticAmmo));
                     });
                 },
                 Impact = LogImpact.Medium,

--- a/Content.Server/DeviceLinking/Systems/GunSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/GunSignalControlSystem.cs
@@ -27,18 +27,18 @@ public sealed partial class GunSignalControlSystem : EntitySystem
             return;
 
         if (args.Port == gunControl.Comp.TriggerPort)
-            _gun.AttemptShoot(gunControl, gun);
+            _gun.AttemptShoot((gunControl, gun));
 
         if (!TryComp<AutoShootGunComponent>(gunControl, out var autoShoot))
             return;
 
         if (args.Port == gunControl.Comp.TogglePort)
-           _gun.SetEnabled(gunControl, autoShoot, !autoShoot.Enabled);
+            _gun.SetEnabled((gunControl, autoShoot), !autoShoot.Enabled);
 
         if (args.Port == gunControl.Comp.OnPort)
-            _gun.SetEnabled(gunControl, autoShoot, true);
+            _gun.SetEnabled((gunControl, autoShoot), true);
 
         if (args.Port == gunControl.Comp.OffPort)
-            _gun.SetEnabled(gunControl, autoShoot, false);
+            _gun.SetEnabled((gunControl, autoShoot), false);
     }
 }

--- a/Content.Server/NPC/HTN/Preconditions/GunAmmoPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/GunAmmoPrecondition.cs
@@ -10,10 +10,10 @@ public sealed partial class GunAmmoPrecondition : HTNPrecondition
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
 
-    [DataField("minPercent")]
+    [DataField]
     public float MinPercent = 0f;
 
-    [DataField("maxPercent")]
+    [DataField]
     public float MaxPercent = 1f;
 
     public override bool IsMet(NPCBlackboard blackboard)
@@ -21,19 +21,19 @@ public sealed partial class GunAmmoPrecondition : HTNPrecondition
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
         var gunSystem = _entManager.System<GunSystem>();
 
-        if (!gunSystem.TryGetGun(owner, out var gunUid, out _))
+        if (!gunSystem.TryGetGun(owner, out var gun))
         {
             return false;
         }
 
         var ammoEv = new GetAmmoCountEvent();
-        _entManager.EventBus.RaiseLocalEvent(gunUid, ref ammoEv);
+        _entManager.EventBus.RaiseLocalEvent(gun, ref ammoEv);
         float percent;
 
         if (ammoEv.Capacity == 0)
             percent = 0f;
         else
-            percent = ammoEv.Count / (float) ammoEv.Capacity;
+            percent = ammoEv.Count / (float)ammoEv.Capacity;
 
         percent = System.Math.Clamp(percent, 0f, 1f);
 

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -96,7 +96,7 @@ public sealed partial class NPCCombatSystem
                 _combat.SetInCombatMode(uid, true, combatMode);
             }
 
-            if (!_gun.TryGetGun(uid, out var gunUid, out var gun))
+            if (!_gun.TryGetGun(uid, out var gun))
             {
                 comp.Status = CombatStatus.NoWeapon;
                 comp.ShootAccumulator = 0f;
@@ -104,12 +104,12 @@ public sealed partial class NPCCombatSystem
             }
 
             var ammoEv = new GetAmmoCountEvent();
-            RaiseLocalEvent(gunUid, ref ammoEv);
+            RaiseLocalEvent(gun, ref ammoEv);
 
             if (ammoEv.Count == 0)
             {
                 // Recharging then?
-                if (_rechargeQuery.HasComponent(gunUid))
+                if (_rechargeQuery.HasComponent(gun))
                 {
                     continue;
                 }
@@ -200,12 +200,12 @@ public sealed partial class NPCCombatSystem
 
             comp.Status = CombatStatus.Normal;
 
-            if (gun.NextFire > _timing.CurTime)
+            if (gun.Comp.NextFire > _timing.CurTime)
             {
                 return;
             }
 
-            _gun.AttemptShoot(uid, gunUid, gun, targetCordinates, comp.Target);
+            _gun.AttemptShoot(uid, gun, targetCordinates, comp.Target);
         }
     }
 }

--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -232,7 +232,7 @@ namespace Content.Server.Singularity.EntitySystems
 
             var targetPos = new EntityCoordinates(uid, new Vector2(0, -1));
 
-            _gun.Shoot(uid, gunComponent, ent, xform.Coordinates, targetPos, out _);
+            _gun.Shoot((uid, gunComponent), ent, xform.Coordinates, targetPos, out _);
         }
 
         private void UpdateAppearance(EntityUid uid, EmitterComponent component)

--- a/Content.Server/Turrets/DeployableTurretSystem.cs
+++ b/Content.Server/Turrets/DeployableTurretSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class DeployableTurretSystem : SharedDeployableTurretSyste
             args.Data.TryGetValue(command, out int? armamentState))
         {
             if (TryComp<BatteryWeaponFireModesComponent>(ent, out var batteryWeaponFireModes))
-                _fireModes.TrySetFireMode(ent, batteryWeaponFireModes, armamentState.Value);
+                _fireModes.TrySetFireMode((ent, batteryWeaponFireModes), armamentState.Value);
 
             TrySetState(ent, armamentState.Value >= 0);
             return;

--- a/Content.Server/Weapons/DamageMarkerSystem.cs
+++ b/Content.Server/Weapons/DamageMarkerSystem.cs
@@ -2,7 +2,4 @@ using Content.Shared.Weapons.Marker;
 
 namespace Content.Server.Weapons;
 
-public sealed class DamageMarkerSystem : SharedDamageMarkerSystem
-{
-
-}
+public sealed class DamageMarkerSystem : SharedDamageMarkerSystem { }

--- a/Content.Server/Weapons/Ranged/Components/AmmoCounterComponent.cs
+++ b/Content.Server/Weapons/Ranged/Components/AmmoCounterComponent.cs
@@ -3,4 +3,4 @@ using Content.Shared.Weapons.Ranged.Components;
 namespace Content.Server.Weapons.Ranged.Components;
 
 [RegisterComponent]
-public sealed partial class AmmoCounterComponent : SharedAmmoCounterComponent {}
+public sealed partial class AmmoCounterComponent : SharedAmmoCounterComponent { }

--- a/Content.Server/Weapons/Ranged/Components/ChemicalAmmoComponent.cs
+++ b/Content.Server/Weapons/Ranged/Components/ChemicalAmmoComponent.cs
@@ -1,11 +1,10 @@
-namespace Content.Server.Weapons.Ranged.Components
-{
-    [RegisterComponent]
-    public sealed partial class ChemicalAmmoComponent : Component
-    {
-        public const string DefaultSolutionName = "ammo";
+namespace Content.Server.Weapons.Ranged.Components;
 
-        [DataField("solution")]
-        public string SolutionName { get; set; } = DefaultSolutionName;
-    }
+[RegisterComponent]
+public sealed partial class ChemicalAmmoComponent : Component
+{
+    public const string DefaultSolutionName = "ammo";
+
+    [DataField("solution")]
+    public string SolutionName { get; set; } = DefaultSolutionName;
 }

--- a/Content.Server/Weapons/Ranged/Components/RangedDamageSoundComponent.cs
+++ b/Content.Server/Weapons/Ranged/Components/RangedDamageSoundComponent.cs
@@ -16,15 +16,13 @@ public sealed partial class RangedDamageSoundComponent : Component
     /// Specified sounds to apply when the entity takes damage with the specified group.
     /// Will fallback to defaults if none specified.
     /// </summary>
-    [DataField("soundGroups",
-        customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, DamageGroupPrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, DamageGroupPrototype>))]
     public Dictionary<string, SoundSpecifier>? SoundGroups;
 
     /// <summary>
     /// Specified sounds to apply when the entity takes damage with the specified type.
     /// Will fallback to defaults if none specified.
     /// </summary>
-    [DataField("soundTypes",
-         customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, DamageTypePrototype>))]
+    [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<SoundSpecifier, DamageTypePrototype>))]
     public Dictionary<string, SoundSpecifier>? SoundTypes;
 }

--- a/Content.Server/Weapons/Ranged/Systems/ChemicalAmmoSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/ChemicalAmmoSystem.cs
@@ -1,49 +1,48 @@
 using Content.Server.Weapons.Ranged.Components;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Weapons.Ranged.Events;
 using System.Linq;
 
-namespace Content.Server.Weapons.Ranged.Systems
+namespace Content.Server.Weapons.Ranged.Systems;
+
+public sealed class ChemicalAmmoSystem : EntitySystem
 {
-    public sealed class ChemicalAmmoSystem : EntitySystem
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+
+    public override void Initialize()
     {
-        [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+        SubscribeLocalEvent<ChemicalAmmoComponent, AmmoShotEvent>(OnFire);
+    }
 
-        public override void Initialize()
+    private void OnFire(Entity<ChemicalAmmoComponent> entity, ref AmmoShotEvent args)
+    {
+        if (!_solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var ammoSoln, out var ammoSolution))
+            return;
+
+        var projectiles = args.FiredProjectiles;
+
+        var projectileSolutionContainers = new List<(EntityUid, Entity<SolutionComponent>)>();
+        foreach (var projectile in projectiles)
         {
-            SubscribeLocalEvent<ChemicalAmmoComponent, AmmoShotEvent>(OnFire);
+            if (_solutionContainerSystem
+                .TryGetSolution(projectile, entity.Comp.SolutionName, out var projectileSoln, out _))
+            {
+                projectileSolutionContainers.Add((projectile, projectileSoln.Value));
+            }
         }
 
-        private void OnFire(Entity<ChemicalAmmoComponent> entity, ref AmmoShotEvent args)
+        if (!projectileSolutionContainers.Any())
+            return;
+
+        var solutionPerProjectile = ammoSolution.Volume * (1 / projectileSolutionContainers.Count);
+
+        foreach (var (_, projectileSolution) in projectileSolutionContainers)
         {
-            if (!_solutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.SolutionName, out var ammoSoln, out var ammoSolution))
-                return;
-
-            var projectiles = args.FiredProjectiles;
-
-            var projectileSolutionContainers = new List<(EntityUid, Entity<SolutionComponent>)>();
-            foreach (var projectile in projectiles)
-            {
-                if (_solutionContainerSystem
-                    .TryGetSolution(projectile, entity.Comp.SolutionName, out var projectileSoln, out _))
-                {
-                    projectileSolutionContainers.Add((projectile, projectileSoln.Value));
-                }
-            }
-
-            if (!projectileSolutionContainers.Any())
-                return;
-
-            var solutionPerProjectile = ammoSolution.Volume * (1 / projectileSolutionContainers.Count);
-
-            foreach (var (_, projectileSolution) in projectileSolutionContainers)
-            {
-                var solutionToTransfer = _solutionContainerSystem.SplitSolution(ammoSoln.Value, solutionPerProjectile);
-                _solutionContainerSystem.TryAddSolution(projectileSolution, solutionToTransfer);
-            }
-
-            _solutionContainerSystem.RemoveAllSolution(ammoSoln.Value);
+            var solutionToTransfer = _solutionContainerSystem.SplitSolution(ammoSoln.Value, solutionPerProjectile);
+            _solutionContainerSystem.TryAddSolution(projectileSolution, solutionToTransfer);
         }
+
+        _solutionContainerSystem.RemoveAllSolution(ammoSoln.Value);
     }
 }

--- a/Content.Server/Weapons/Ranged/Systems/FlyBySoundSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/FlyBySoundSystem.cs
@@ -2,4 +2,4 @@ using Content.Shared.Weapons.Ranged.Systems;
 
 namespace Content.Server.Weapons.Ranged.Systems;
 
-public sealed class FlyBySoundSystem : SharedFlyBySoundSystem {}
+public sealed class FlyBySoundSystem : SharedFlyBySoundSystem { }

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.AutoFire.cs
@@ -27,15 +27,15 @@ public sealed partial class GunSystem
                 if (!autoShoot.Enabled)
                     continue;
 
-                AttemptShoot(uid, gun);
+                AttemptShoot((uid, gun));
             }
             else if (gun.BurstActivated)
             {
                 var parent = TransformSystem.GetParentUid(uid);
                 if (HasComp<DamageableComponent>(parent))
-                    AttemptShoot(parent, uid, gun, gun.ShootCoordinates ?? new EntityCoordinates(uid, gun.DefaultDirection));
+                    AttemptShoot(parent, (uid, gun), gun.ShootCoordinates ?? new EntityCoordinates(uid, gun.DefaultDirection));
                 else
-                    AttemptShoot(uid, gun);
+                    AttemptShoot((uid, gun));
             }
         }
     }

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -6,32 +6,32 @@ namespace Content.Server.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
-    protected override void Cycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates)
+    protected override void Cycle(Entity<BallisticAmmoProviderComponent> ent, MapCoordinates coordinates)
     {
-        EntityUid? ent = null;
+        EntityUid? ammoEnt = null;
 
         // TODO: Combine with TakeAmmo
-        if (component.Entities.Count > 0)
+        if (ent.Comp.Entities.Count > 0)
         {
-            var existing = component.Entities[^1];
-            component.Entities.RemoveAt(component.Entities.Count - 1);
-            DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
+            var existing = ent.Comp.Entities[^1];
+            ent.Comp.Entities.RemoveAt(ent.Comp.Entities.Count - 1);
+            DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.Entities));
 
-            Containers.Remove(existing, component.Container);
+            Containers.Remove(existing, ent.Comp.Container);
             EnsureShootable(existing);
         }
-        else if (component.UnspawnedCount > 0)
+        else if (ent.Comp.UnspawnedCount > 0)
         {
-            component.UnspawnedCount--;
-            DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.UnspawnedCount));
-            ent = Spawn(component.Proto, coordinates);
-            EnsureShootable(ent.Value);
+            ent.Comp.UnspawnedCount--;
+            DirtyField(ent.AsNullable(), nameof(BallisticAmmoProviderComponent.UnspawnedCount));
+            ammoEnt = Spawn(ent.Comp.Proto, coordinates);
+            EnsureShootable(ammoEnt.Value);
         }
 
-        if (ent != null)
-            EjectCartridge(ent.Value);
+        if (ammoEnt != null)
+            EjectCartridge(ammoEnt.Value);
 
         var cycledEvent = new GunCycledEvent();
-        RaiseLocalEvent(uid, ref cycledEvent);
+        RaiseLocalEvent(ent, ref cycledEvent);
     }
 }

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Revolver.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Revolver.cs
@@ -4,15 +4,15 @@ namespace Content.Server.Weapons.Ranged.Systems;
 
 public sealed partial class GunSystem
 {
-    protected override void SpinRevolver(EntityUid revolverUid, RevolverAmmoProviderComponent component, EntityUid? user = null)
+    protected override void SpinRevolver(Entity<RevolverAmmoProviderComponent> ent, EntityUid? user = null)
     {
-        base.SpinRevolver(revolverUid, component, user);
-        var index = Random.Next(component.Capacity);
+        base.SpinRevolver(ent, user);
+        var index = Random.Next(ent.Comp.Capacity);
 
-        if (component.CurrentIndex == index)
+        if (ent.Comp.CurrentIndex == index)
             return;
 
-        component.CurrentIndex = index;
-        Dirty(revolverUid, component);
+        ent.Comp.CurrentIndex = index;
+        Dirty(ent);
     }
 }

--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -70,4 +70,17 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> NestedStorage =
         CVarDef.Create("control.nested_storage", true, CVar.REPLICATED | CVar.SERVER);
+
+    /// <summary>
+    ///     If enabled, melee weapons that have click-to-attack patterns (unarmed, slow weapons) will continue attacking if the button is held.
+    /// </summary>
+    public static readonly CVarDef<bool> ControlHoldToAttackMelee =
+        CVarDef.Create("control.hold_to_attack_melee", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    ///     If enabled, ranged weapons that have click-to-attack patterns (burst and semi-auto guns) will continue attacking if the button is held.
+    /// </summary>
+    public static readonly CVarDef<bool> ControlHoldToAttackRanged =
+        CVarDef.Create("control.hold_to_attack_ranged", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
 }

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -461,7 +461,7 @@ public abstract class SharedMagicSystem : EntitySystem
             return;
 
         if (TryComp<BasicEntityAmmoProviderComponent>(wand, out var basicAmmoComp) && basicAmmoComp.Count != null)
-            _gunSystem.UpdateBasicEntityAmmoCount(wand.Value, basicAmmoComp.Count.Value + ev.Charge, basicAmmoComp);
+            _gunSystem.UpdateBasicEntityAmmoCount((wand.Value, basicAmmoComp), basicAmmoComp.Count.Value + ev.Charge);
         else if (TryComp<LimitedChargesComponent>(wand, out var charges))
             _charges.AddCharges((wand.Value, charges), ev.Charge);
     }

--- a/Content.Shared/Weapons/Ranged/Components/ChamberMagazineAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/ChamberMagazineAmmoProviderComponent.cs
@@ -13,27 +13,27 @@ public sealed partial class ChamberMagazineAmmoProviderComponent : MagazineAmmoP
     /// <summary>
     /// If the gun has a bolt and whether that bolt is closed. Firing is impossible
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("boltClosed"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool? BoltClosed = false;
 
     /// <summary>
     /// Does the gun automatically open and close the bolt upon shooting.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("autoCycle"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool AutoCycle = true;
 
     /// <summary>
     /// Can the gun be racked, which opens and then instantly closes the bolt to cycle a round.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("canRack"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool CanRack = true;
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("soundBoltClosed"), AutoNetworkedField]
+    [DataField("soundBoltClosed"), AutoNetworkedField]
     public SoundSpecifier? BoltClosedSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Bolt/rifle_bolt_closed.ogg");
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("soundBoltOpened"), AutoNetworkedField]
+    [DataField("soundBoltOpened"), AutoNetworkedField]
     public SoundSpecifier? BoltOpenedSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Bolt/rifle_bolt_open.ogg");
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("soundRack"), AutoNetworkedField]
+    [DataField("soundRack"), AutoNetworkedField]
     public SoundSpecifier? RackSound = new SoundPathSpecifier("/Audio/Weapons/Guns/Cock/ltrifle_cock.ogg");
 }

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -225,7 +225,7 @@ public sealed partial class GunComponent : Component
     /// When the gun is next available to be shot.
     /// Can be set multiple times in a single tick due to guns firing faster than a single tick time.
     /// </summary>
-    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoNetworkedField]
     [AutoPausedField]
     public TimeSpan NextFire = TimeSpan.Zero;

--- a/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Weapons.Ranged.Components;
 /// This component modifies the spread of the gun it is attached to.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class GunSpreadModifierComponent: Component
+public sealed partial class GunSpreadModifierComponent : Component
 {
     /// <summary>
     /// A scalar value multiplied by the spread built into the ammo itself.

--- a/Content.Shared/Weapons/Ranged/Components/MagazineAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/MagazineAmmoProviderComponent.cs
@@ -11,12 +11,12 @@ namespace Content.Shared.Weapons.Ranged;
 [Access(typeof(SharedGunSystem))]
 public partial class MagazineAmmoProviderComponent : AmmoProviderComponent
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("soundAutoEject")]
+    [DataField]
     public SoundSpecifier? SoundAutoEject = new SoundPathSpecifier("/Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg");
 
     /// <summary>
     /// Should the magazine automatically eject when empty.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("autoEject")]
+    [DataField]
     public bool AutoEject = false;
 }

--- a/Content.Shared/Weapons/Ranged/Events/RequestShootEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/RequestShootEvent.cs
@@ -9,7 +9,24 @@ namespace Content.Shared.Weapons.Ranged.Events;
 [Serializable, NetSerializable]
 public sealed class RequestShootEvent : EntityEventArgs
 {
+    /// <summary>
+    /// The gun shooting.
+    /// </summary>
     public NetEntity Gun;
+
+    /// <summary>
+    /// The location the player is shooting at.
+    /// </summary>
     public NetCoordinates Coordinates;
+
+    /// <summary>
+    /// The target the player is shooting at, if any.
+    /// </summary>
     public NetEntity? Target;
+
+    /// <summary>
+    /// If the client wants to continuously shoot.
+    /// If true, the gun will continue firing until a stop event is sent from the client.
+    /// </summary>
+    public bool Continuous;
 }

--- a/Content.Shared/Weapons/Ranged/Events/RequestStopShootEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/RequestStopShootEvent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Weapons.Ranged.Events;
 
 /// <summary>
-/// Raised on the client to request it would like to stop hooting.
+/// Raised on the client to request it would like to stop shooting.
 /// </summary>
 [Serializable, NetSerializable]
 public sealed class RequestStopShootEvent : EntityEventArgs

--- a/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/ActionGunSystem.cs
@@ -28,14 +28,14 @@ public sealed class ActionGunSystem : EntitySystem
 
     private void OnShutdown(Entity<ActionGunComponent> ent, ref ComponentShutdown args)
     {
-        if (ent.Comp.Gun is {} gun)
+        if (ent.Comp.Gun is { } gun)
             QueueDel(gun);
     }
 
     private void OnShoot(Entity<ActionGunComponent> ent, ref ActionGunShootEvent args)
     {
         if (TryComp<GunComponent>(ent.Comp.Gun, out var gun))
-            _gun.AttemptShoot(ent, ent.Comp.Gun.Value, gun, args.Target);
+            _gun.AttemptShoot(ent, (ent.Comp.Gun.Value, gun), args.Target);
     }
 }
 

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Database;
 using Content.Shared.Examine;
@@ -6,18 +5,17 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
-using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
 public sealed class BatteryWeaponFireModesSystem : EntitySystem
 {
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly SharedGunSystem _gun = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
 
     public override void Initialize()
     {
@@ -28,12 +26,12 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
         SubscribeLocalEvent<BatteryWeaponFireModesComponent, ExaminedEvent>(OnExamined);
     }
 
-    private void OnExamined(EntityUid uid, BatteryWeaponFireModesComponent component, ExaminedEvent args)
+    private void OnExamined(Entity<BatteryWeaponFireModesComponent> ent, ref ExaminedEvent args)
     {
-        if (component.FireModes.Count < 2)
+        if (ent.Comp.FireModes.Count < 2)
             return;
 
-        var fireMode = GetMode(component);
+        var fireMode = GetMode(ent.Comp);
 
         if (!_prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var proto))
             return;
@@ -74,7 +72,7 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
                 DoContactInteraction = true,
                 Act = () =>
                 {
-                    TrySetFireMode(uid, component, index, args.User);
+                    TrySetFireMode((uid, component), index, args.User);
                 }
             };
 
@@ -82,60 +80,60 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
         }
     }
 
-    private void OnUseInHandEvent(EntityUid uid, BatteryWeaponFireModesComponent component, UseInHandEvent args)
+    private void OnUseInHandEvent(Entity<BatteryWeaponFireModesComponent> ent, ref UseInHandEvent args)
     {
-        if(args.Handled)
+        if (args.Handled)
             return;
 
         args.Handled = true;
-        TryCycleFireMode(uid, component, args.User);
+        TryCycleFireMode(ent, args.User);
     }
 
-    public void TryCycleFireMode(EntityUid uid, BatteryWeaponFireModesComponent component, EntityUid? user = null)
+    public void TryCycleFireMode(Entity<BatteryWeaponFireModesComponent> ent, EntityUid? user = null)
     {
-        if (component.FireModes.Count < 2)
+        if (ent.Comp.FireModes.Count < 2)
             return;
 
-        var index = (component.CurrentFireMode + 1) % component.FireModes.Count;
-        TrySetFireMode(uid, component, index, user);
+        var index = (ent.Comp.CurrentFireMode + 1) % ent.Comp.FireModes.Count;
+        TrySetFireMode(ent, index, user);
     }
 
-    public bool TrySetFireMode(EntityUid uid, BatteryWeaponFireModesComponent component, int index, EntityUid? user = null)
+    public bool TrySetFireMode(Entity<BatteryWeaponFireModesComponent> ent, int index, EntityUid? user = null)
     {
-        if (index < 0 || index >= component.FireModes.Count)
+        if (index < 0 || index >= ent.Comp.FireModes.Count)
             return false;
 
-        if (user != null && !_accessReaderSystem.IsAllowed(user.Value, uid))
+        if (user != null && !_accessReaderSystem.IsAllowed(user.Value, ent))
             return false;
 
-        SetFireMode(uid, component, index, user);
+        SetFireMode(ent, index, user);
 
         return true;
     }
 
-    private void SetFireMode(EntityUid uid, BatteryWeaponFireModesComponent component, int index, EntityUid? user = null)
+    private void SetFireMode(Entity<BatteryWeaponFireModesComponent> ent, int index, EntityUid? user = null)
     {
-        var fireMode = component.FireModes[index];
-        component.CurrentFireMode = index;
-        Dirty(uid, component);
+        var fireMode = ent.Comp.FireModes[index];
+        ent.Comp.CurrentFireMode = index;
+        Dirty(ent);
 
         if (_prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var prototype))
         {
-            if (TryComp<AppearanceComponent>(uid, out var appearance))
-                _appearanceSystem.SetData(uid, BatteryWeaponFireModeVisuals.State, prototype.ID, appearance);
+            if (TryComp<AppearanceComponent>(ent, out var appearance))
+                _appearanceSystem.SetData(ent, BatteryWeaponFireModeVisuals.State, prototype.ID, appearance);
 
             if (user != null)
-                 _popupSystem.PopupClient(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), uid, user.Value);
+                _popupSystem.PopupClient(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), ent, user.Value);
         }
 
-        if (TryComp(uid, out BatteryAmmoProviderComponent? batteryAmmoProviderComponent))
+        if (TryComp(ent, out BatteryAmmoProviderComponent? batteryAmmoProviderComponent))
         {
             batteryAmmoProviderComponent.Prototype = fireMode.Prototype;
             batteryAmmoProviderComponent.FireCost = fireMode.FireCost;
 
-            Dirty(uid, batteryAmmoProviderComponent);
+            Dirty(ent, batteryAmmoProviderComponent);
 
-            _gun.UpdateShots((uid, batteryAmmoProviderComponent));
+            _gun.UpdateShots((ent, batteryAmmoProviderComponent));
         }
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -4,8 +4,7 @@ using Content.Shared.Weapons.Ranged.Events;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
-
-public sealed class GunSpreadModifierSystem: EntitySystem
+public sealed class GunSpreadModifierSystem : EntitySystem
 {
     public override void Initialize()
     {
@@ -14,14 +13,14 @@ public sealed class GunSpreadModifierSystem: EntitySystem
         SubscribeLocalEvent<GunSpreadModifierComponent, ExaminedEvent>(OnExamine);
     }
 
-    private void OnGunGetAmmoSpread(EntityUid uid, GunSpreadModifierComponent comp, ref GunGetAmmoSpreadEvent args)
+    private void OnGunGetAmmoSpread(Entity<GunSpreadModifierComponent> ent, ref GunGetAmmoSpreadEvent args)
     {
-        args.Spread *= comp.Spread;
+        args.Spread *= ent.Comp.Spread;
     }
 
-    private void OnExamine(EntityUid uid, GunSpreadModifierComponent comp, ExaminedEvent args)
+    private void OnExamine(Entity<GunSpreadModifierComponent> ent, ref ExaminedEvent args)
     {
-        var percentage = Math.Round(comp.Spread * 100);
+        var percentage = Math.Round(ent.Comp.Spread * 100);
         var loc = percentage < 100 ? "examine-gun-spread-modifier-reduction" : "examine-gun-spread-modifier-increase";
         percentage = percentage < 100 ? 100 - percentage : percentage - 100;
         var msg = Loc.GetString(loc, ("percentage", percentage));

--- a/Content.Shared/Weapons/Ranged/Systems/RechargeCycleAmmoSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/RechargeCycleAmmoSystem.cs
@@ -16,19 +16,19 @@ public sealed class RechargeCycleAmmoSystem : EntitySystem
         SubscribeLocalEvent<RechargeCycleAmmoComponent, ActivateInWorldEvent>(OnRechargeCycled);
     }
 
-    private void OnRechargeCycled(EntityUid uid, RechargeCycleAmmoComponent component, ActivateInWorldEvent args)
+    private void OnRechargeCycled(Entity<RechargeCycleAmmoComponent> ent, ref ActivateInWorldEvent args)
     {
         if (!args.Complex)
             return;
 
-        if (!TryComp<BasicEntityAmmoProviderComponent>(uid, out var basic) || args.Handled)
+        if (!TryComp<BasicEntityAmmoProviderComponent>(ent, out var basic) || args.Handled)
             return;
 
         if (basic.Count >= basic.Capacity || basic.Count == null)
             return;
 
-        _gun.UpdateBasicEntityAmmoCount(uid, basic.Count.Value + 1, basic);
-        Dirty(uid, basic);
+        _gun.UpdateBasicEntityAmmoCount((ent, basic), basic.Count.Value + 1);
+        Dirty(ent, basic);
         args.Handled = true;
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedFlyBySoundSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedFlyBySoundSystem.cs
@@ -24,24 +24,24 @@ public abstract class SharedFlyBySoundSystem : EntitySystem
         SubscribeLocalEvent<FlyBySoundComponent, ComponentShutdown>(OnShutdown);
     }
 
-    private void OnStartup(EntityUid uid, FlyBySoundComponent component, ComponentStartup args)
+    private void OnStartup(Entity<FlyBySoundComponent> ent, ref ComponentStartup args)
     {
-        if (!TryComp<PhysicsComponent>(uid, out var body))
+        if (!TryComp<PhysicsComponent>(ent, out var body))
             return;
 
-        var shape = new PhysShapeCircle(component.Range);
+        var shape = new PhysShapeCircle(ent.Comp.Range);
 
-        _fixtures.TryCreateFixture(uid, shape, FlyByFixture, collisionLayer: (int) CollisionGroup.MobMask, hard: false, body: body);
+        _fixtures.TryCreateFixture(ent, shape, FlyByFixture, collisionLayer: (int)CollisionGroup.MobMask, hard: false, body: body);
     }
 
-    private void OnShutdown(EntityUid uid, FlyBySoundComponent component, ComponentShutdown args)
+    private void OnShutdown(Entity<FlyBySoundComponent> ent, ref ComponentShutdown args)
     {
-        if (!TryComp<PhysicsComponent>(uid, out var body) ||
-            MetaData(uid).EntityLifeStage >= EntityLifeStage.Terminating)
+        if (!TryComp<PhysicsComponent>(ent, out var body) ||
+            MetaData(ent).EntityLifeStage >= EntityLifeStage.Terminating)
         {
             return;
         }
 
-        _fixtures.DestroyFixture(uid, FlyByFixture, body: body);
+        _fixtures.DestroyFixture(ent, FlyByFixture, body: body);
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.AutoFire.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.AutoFire.cs
@@ -4,8 +4,8 @@ namespace Content.Shared.Weapons.Ranged.Systems;
 
 public partial class SharedGunSystem
 {
-    public void SetEnabled(EntityUid uid, AutoShootGunComponent component, bool status)
+    public void SetEnabled(Entity<AutoShootGunComponent> ent, bool status)
     {
-        component.Enabled = status;
+        ent.Comp.Enabled = status;
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.BasicEntity.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.BasicEntity.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
-using Robust.Shared.GameStates;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -13,75 +12,70 @@ public abstract partial class SharedGunSystem
         SubscribeLocalEvent<BasicEntityAmmoProviderComponent, GetAmmoCountEvent>(OnBasicEntityAmmoCount);
     }
 
-    private void OnBasicEntityMapInit(EntityUid uid, BasicEntityAmmoProviderComponent component, MapInitEvent args)
+    private void OnBasicEntityMapInit(Entity<BasicEntityAmmoProviderComponent> ent, ref MapInitEvent args)
     {
-        if (component.Count is null)
+        if (ent.Comp.Count is null)
         {
-            component.Count = component.Capacity;
-            Dirty(uid, component);
+            ent.Comp.Count = ent.Comp.Capacity;
+            Dirty(ent);
         }
 
-        UpdateBasicEntityAppearance(uid, component);
+        UpdateBasicEntityAppearance(ent);
     }
 
-    private void OnBasicEntityTakeAmmo(EntityUid uid, BasicEntityAmmoProviderComponent component, TakeAmmoEvent args)
+    private void OnBasicEntityTakeAmmo(Entity<BasicEntityAmmoProviderComponent> ent, ref TakeAmmoEvent args)
     {
         for (var i = 0; i < args.Shots; i++)
         {
-            if (component.Count <= 0)
+            if (ent.Comp.Count <= 0)
                 return;
 
-            if (component.Count != null)
-            {
-                component.Count--;
-            }
+            if (ent.Comp.Count != null)
+                ent.Comp.Count--;
 
-            var ent = Spawn(component.Proto, args.Coordinates);
-            args.Ammo.Add((ent, EnsureShootable(ent)));
+            var ammoEnt = Spawn(ent.Comp.Proto, args.Coordinates);
+            args.Ammo.Add((ammoEnt, EnsureShootable(ammoEnt)));
         }
 
-        _recharge.Reset(uid);
-        UpdateBasicEntityAppearance(uid, component);
-        Dirty(uid, component);
+        _recharge.Reset(ent.Owner);
+        UpdateBasicEntityAppearance(ent);
+        Dirty(ent);
     }
 
-    private void OnBasicEntityAmmoCount(EntityUid uid, BasicEntityAmmoProviderComponent component, ref GetAmmoCountEvent args)
+    private void OnBasicEntityAmmoCount(Entity<BasicEntityAmmoProviderComponent> ent, ref GetAmmoCountEvent args)
     {
-        args.Capacity = component.Capacity ?? int.MaxValue;
-        args.Count = component.Count ?? int.MaxValue;
+        args.Capacity = ent.Comp.Capacity ?? int.MaxValue;
+        args.Count = ent.Comp.Count ?? int.MaxValue;
     }
 
-    private void UpdateBasicEntityAppearance(EntityUid uid, BasicEntityAmmoProviderComponent component)
+    private void UpdateBasicEntityAppearance(Entity<BasicEntityAmmoProviderComponent> ent)
     {
-        if (!Timing.IsFirstTimePredicted || !TryComp<AppearanceComponent>(uid, out var appearance))
+        if (!Timing.IsFirstTimePredicted || !TryComp<AppearanceComponent>(ent, out var appearance))
             return;
 
-        Appearance.SetData(uid, AmmoVisuals.HasAmmo, component.Count != 0, appearance);
-        Appearance.SetData(uid, AmmoVisuals.AmmoCount, component.Count ?? int.MaxValue, appearance);
-        Appearance.SetData(uid, AmmoVisuals.AmmoMax, component.Capacity ?? int.MaxValue, appearance);
+        Appearance.SetData(ent, AmmoVisuals.HasAmmo, ent.Comp.Count != 0, appearance);
+        Appearance.SetData(ent, AmmoVisuals.AmmoCount, ent.Comp.Count ?? int.MaxValue, appearance);
+        Appearance.SetData(ent, AmmoVisuals.AmmoMax, ent.Comp.Capacity ?? int.MaxValue, appearance);
     }
 
     #region Public API
-    public bool ChangeBasicEntityAmmoCount(EntityUid uid, int delta, BasicEntityAmmoProviderComponent? component = null)
+    public bool ChangeBasicEntityAmmoCount(Entity<BasicEntityAmmoProviderComponent?> ent, int delta)
     {
-        if (!Resolve(uid, ref component, false) || component.Count == null)
+        if (!Resolve(ent, ref ent.Comp, false) || ent.Comp.Count == null)
             return false;
 
-        return UpdateBasicEntityAmmoCount(uid, component.Count.Value + delta, component);
+        return UpdateBasicEntityAmmoCount((ent.Owner, ent.Comp), ent.Comp.Count.Value + delta);
     }
 
-    public bool UpdateBasicEntityAmmoCount(EntityUid uid, int count, BasicEntityAmmoProviderComponent? component = null)
+    public bool UpdateBasicEntityAmmoCount(Entity<BasicEntityAmmoProviderComponent?> ent, int count)
     {
-        if (!Resolve(uid, ref component, false))
+        if (!Resolve(ent, ref ent.Comp, false) || count > ent.Comp.Capacity)
             return false;
 
-        if (count > component.Capacity)
-            return false;
-
-        component.Count = count;
-        UpdateBasicEntityAppearance(uid, component);
-        UpdateAmmoCount(uid);
-        Dirty(uid, component);
+        ent.Comp.Count = count;
+        UpdateBasicEntityAppearance((ent.Owner, ent.Comp));
+        UpdateAmmoCount(ent);
+        Dirty(ent);
 
         return true;
     }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
@@ -26,9 +26,9 @@ public abstract partial class SharedGunSystem
             : Loc.GetString("gun-cartridge-unspent"));
     }
 
-    private void OnCartridgeDamageExamine(EntityUid uid, CartridgeAmmoComponent component, ref DamageExamineEvent args)
+    private void OnCartridgeDamageExamine(Entity<CartridgeAmmoComponent> ent, ref DamageExamineEvent args)
     {
-        var damageSpec = GetProjectileDamage(component.Prototype);
+        var damageSpec = GetProjectileDamage(ent.Comp.Prototype);
 
         if (damageSpec == null)
             return;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -12,8 +12,6 @@ namespace Content.Shared.Weapons.Ranged.Systems;
 
 public abstract partial class SharedGunSystem
 {
-    protected const string ChamberSlot = "gun_chamber";
-
     protected virtual void InitializeChamberMagazine()
     {
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, ComponentStartup>(OnChamberStartup);
@@ -42,7 +40,7 @@ public abstract partial class SharedGunSystem
         // Appearance data doesn't get serialized and want to make sure this is correct on spawn (regardless of MapInit) so.
         if (component.BoltClosed != null)
         {
-           Appearance.SetData(uid, AmmoVisuals.BoltClosed, component.BoltClosed.Value);
+            Appearance.SetData(uid, AmmoVisuals.BoltClosed, component.BoltClosed.Value);
         }
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Clothing.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Clothing.cs
@@ -16,7 +16,7 @@ public partial class SharedGunSystem
     {
         var getConnectedContainerEvent = new GetConnectedContainerEvent();
         RaiseLocalEvent(uid, ref getConnectedContainerEvent);
-        if(!getConnectedContainerEvent.ContainerEntity.HasValue)
+        if (!getConnectedContainerEvent.ContainerEntity.HasValue)
             return;
 
         RaiseLocalEvent(getConnectedContainerEvent.ContainerEntity.Value, args);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Container.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Container.cs
@@ -14,10 +14,10 @@ public partial class SharedGunSystem
         SubscribeLocalEvent<ContainerAmmoProviderComponent, GetAmmoCountEvent>(OnContainerAmmoCount);
     }
 
-    private void OnContainerTakeAmmo(EntityUid uid, ContainerAmmoProviderComponent component, TakeAmmoEvent args)
+    private void OnContainerTakeAmmo(Entity<ContainerAmmoProviderComponent> ent, ref TakeAmmoEvent args)
     {
-        component.ProviderUid ??= uid;
-        if (!Containers.TryGetContainer(component.ProviderUid.Value, component.Container, out var container))
+        ent.Comp.ProviderUid ??= ent;
+        if (!Containers.TryGetContainer(ent.Comp.ProviderUid.Value, ent.Comp.Container, out var container))
             return;
 
         for (var i = 0; i < args.Shots; i++)
@@ -25,19 +25,19 @@ public partial class SharedGunSystem
             if (!container.ContainedEntities.Any())
                 break;
 
-            var ent = container.ContainedEntities[0];
+            var ammoEnt = container.ContainedEntities[0];
 
             if (_netManager.IsServer)
-                Containers.Remove(ent, container);
+                Containers.Remove(ammoEnt, container);
 
-            args.Ammo.Add((ent, EnsureShootable(ent)));
+            args.Ammo.Add((ammoEnt, EnsureShootable(ammoEnt)));
         }
     }
 
-    private void OnContainerAmmoCount(EntityUid uid, ContainerAmmoProviderComponent component, ref GetAmmoCountEvent args)
+    private void OnContainerAmmoCount(Entity<ContainerAmmoProviderComponent> ent, ref GetAmmoCountEvent args)
     {
-        component.ProviderUid ??= uid;
-        if (!Containers.TryGetContainer(component.ProviderUid.Value, component.Container, out var container))
+        ent.Comp.ProviderUid ??= ent;
+        if (!Containers.TryGetContainer(ent.Comp.ProviderUid.Value, ent.Comp.Container, out var container))
         {
             args.Capacity = 0;
             args.Count = 0;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -66,7 +66,7 @@ public abstract partial class SharedGunSystem
         if (component.SelectedMode == fire)
             return;
 
-        DebugTools.Assert((component.AvailableModes  & fire) != 0x0);
+        DebugTools.Assert((component.AvailableModes & fire) != 0x0);
         component.SelectedMode = fire;
 
         if (!Paused(uid))
@@ -113,7 +113,7 @@ public abstract partial class SharedGunSystem
     private void OnGunSelected(EntityUid uid, GunComponent component, HandSelectedEvent args)
     {
         if (Timing.ApplyingState)
-             return;
+            return;
 
         if (component.FireRateModified <= 0)
             return;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
@@ -8,8 +8,6 @@ namespace Content.Shared.Weapons.Ranged.Systems;
 
 public abstract partial class SharedGunSystem
 {
-    protected const string MagazineSlot = "gun_magazine";
-
     protected virtual void InitializeMagazine()
     {
         SubscribeLocalEvent<MagazineAmmoProviderComponent, MapInitEvent>(OnMagazineMapInit);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -31,82 +31,82 @@ public partial class SharedGunSystem
         SubscribeLocalEvent<RevolverAmmoProviderComponent, UseInHandEvent>(OnRevolverUse);
     }
 
-    private void OnRevolverUse(EntityUid uid, RevolverAmmoProviderComponent component, UseInHandEvent args)
+    private void OnRevolverUse(Entity<RevolverAmmoProviderComponent> ent, ref UseInHandEvent args)
     {
         if (args.Handled)
             return;
 
-        if (!_useDelay.TryResetDelay(uid))
+        if (!_useDelay.TryResetDelay(ent))
             return;
 
         args.Handled = true;
 
-        Cycle(component);
-        UpdateAmmoCount(uid, prediction: false);
-        Dirty(uid, component);
+        Cycle(ent.Comp);
+        UpdateAmmoCount(ent, prediction: false);
+        Dirty(ent);
     }
 
-    private void OnRevolverGetAmmoCount(EntityUid uid, RevolverAmmoProviderComponent component, ref GetAmmoCountEvent args)
+    private void OnRevolverGetAmmoCount(Entity<RevolverAmmoProviderComponent> ent, ref GetAmmoCountEvent args)
     {
-        args.Count += GetRevolverCount(component);
-        args.Capacity += component.Capacity;
+        args.Count += GetRevolverCount(ent.Comp);
+        args.Capacity += ent.Comp.Capacity;
     }
 
-    private void OnRevolverInteractUsing(EntityUid uid, RevolverAmmoProviderComponent component, InteractUsingEvent args)
+    private void OnRevolverInteractUsing(Entity<RevolverAmmoProviderComponent> ent, ref InteractUsingEvent args)
     {
         if (args.Handled)
             return;
 
-        if (TryRevolverInsert(uid, component, args.Used, args.User))
+        if (TryRevolverInsert(ent, args.Used, args.User))
             args.Handled = true;
     }
 
-    private void OnRevolverGetState(EntityUid uid, RevolverAmmoProviderComponent component, ref ComponentGetState args)
+    private void OnRevolverGetState(Entity<RevolverAmmoProviderComponent> ent, ref ComponentGetState args)
     {
         args.State = new RevolverAmmoProviderComponentState
         {
-            CurrentIndex = component.CurrentIndex,
-            AmmoSlots = GetNetEntityList(component.AmmoSlots),
-            Chambers = component.Chambers,
+            CurrentIndex = ent.Comp.CurrentIndex,
+            AmmoSlots = GetNetEntityList(ent.Comp.AmmoSlots),
+            Chambers = ent.Comp.Chambers,
         };
     }
 
-    private void OnRevolverHandleState(EntityUid uid, RevolverAmmoProviderComponent component, ref ComponentHandleState args)
+    private void OnRevolverHandleState(Entity<RevolverAmmoProviderComponent> ent, ref ComponentHandleState args)
     {
         if (args.Current is not RevolverAmmoProviderComponentState state)
             return;
 
-        var oldIndex = component.CurrentIndex;
-        component.CurrentIndex = state.CurrentIndex;
-        component.Chambers = new bool?[state.Chambers.Length];
+        var oldIndex = ent.Comp.CurrentIndex;
+        ent.Comp.CurrentIndex = state.CurrentIndex;
+        ent.Comp.Chambers = new bool?[state.Chambers.Length];
 
         // Need to copy across the state rather than the ref.
-        for (var i = 0; i < component.AmmoSlots.Count; i++)
+        for (var i = 0; i < ent.Comp.AmmoSlots.Count; i++)
         {
-            component.AmmoSlots[i] = EnsureEntity<RevolverAmmoProviderComponent>(state.AmmoSlots[i], uid);
-            component.Chambers[i] = state.Chambers[i];
+            ent.Comp.AmmoSlots[i] = EnsureEntity<RevolverAmmoProviderComponent>(state.AmmoSlots[i], ent);
+            ent.Comp.Chambers[i] = state.Chambers[i];
         }
 
         // Handle spins
         if (oldIndex != state.CurrentIndex)
         {
-            UpdateAmmoCount(uid, prediction: false);
+            UpdateAmmoCount(ent, prediction: false);
         }
     }
 
-    public bool TryRevolverInsert(EntityUid revolverUid, RevolverAmmoProviderComponent component, EntityUid uid, EntityUid? user)
+    public bool TryRevolverInsert(Entity<RevolverAmmoProviderComponent> ent, EntityUid insertEnt, EntityUid? user)
     {
-        if (_whitelistSystem.IsWhitelistFail(component.Whitelist, uid))
+        if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, insertEnt))
             return false;
 
         // If it's a speedloader try to get ammo from it.
-        if (HasComp<SpeedLoaderComponent>(uid))
+        if (HasComp<SpeedLoaderComponent>(insertEnt))
         {
             var freeSlots = 0;
 
-            for (var i = 0; i < component.Capacity; i++)
+            for (var i = 0; i < ent.Comp.Capacity; i++)
             {
-                if (component.AmmoSlots[i] != null || component.Chambers[i] != null)
+                if (ent.Comp.AmmoSlots[i] != null || ent.Comp.Chambers[i] != null)
                     continue;
 
                 freeSlots++;
@@ -114,94 +114,94 @@ public partial class SharedGunSystem
 
             if (freeSlots == 0)
             {
-                Popup(Loc.GetString("gun-revolver-full"), revolverUid, user);
+                Popup(Loc.GetString("gun-revolver-full"), ent, user);
                 return false;
             }
 
             var xformQuery = GetEntityQuery<TransformComponent>();
-            var xform = xformQuery.GetComponent(uid);
+            var xform = xformQuery.GetComponent(insertEnt);
             var ammo = new List<(EntityUid? Entity, IShootable Shootable)>(freeSlots);
             var ev = new TakeAmmoEvent(freeSlots, ammo, xform.Coordinates, user);
-            RaiseLocalEvent(uid, ev);
+            RaiseLocalEvent(insertEnt, ev);
 
             if (ev.Ammo.Count == 0)
             {
-                Popup(Loc.GetString("gun-speedloader-empty"), revolverUid, user);
+                Popup(Loc.GetString("gun-speedloader-empty"), ent, user);
                 return false;
             }
 
-            for (var i = 0; i < component.Capacity; i++)
+            for (var i = 0; i < ent.Comp.Capacity; i++)
             {
-                var index = (component.CurrentIndex + i) % component.Capacity;
+                var index = (ent.Comp.CurrentIndex + i) % ent.Comp.Capacity;
 
-                if (component.AmmoSlots[index] != null ||
-                    component.Chambers[index] != null)
+                if (ent.Comp.AmmoSlots[index] != null ||
+                    ent.Comp.Chambers[index] != null)
                 {
                     continue;
                 }
 
-                var ent = ev.Ammo.Last().Entity;
+                var ammoEnt = ev.Ammo.Last().Entity;
                 ev.Ammo.RemoveAt(ev.Ammo.Count - 1);
 
-                if (ent == null)
+                if (ammoEnt == null)
                 {
                     Log.Error($"Tried to load hitscan into a revolver which is unsupported");
                     continue;
                 }
 
-                component.AmmoSlots[index] = ent.Value;
-                Containers.Insert(ent.Value, component.AmmoContainer);
-                SetChamber(index, component, uid);
+                ent.Comp.AmmoSlots[index] = ammoEnt.Value;
+                Containers.Insert(ammoEnt.Value, ent.Comp.AmmoContainer);
+                SetChamber(ent, insertEnt, index);
 
                 if (ev.Ammo.Count == 0)
                     break;
             }
 
             DebugTools.Assert(ammo.Count == 0);
-            UpdateRevolverAppearance(revolverUid, component);
-            UpdateAmmoCount(revolverUid);
-            Dirty(revolverUid, component);
+            UpdateRevolverAppearance(ent);
+            UpdateAmmoCount(ent);
+            Dirty(ent);
 
-            Audio.PlayPredicted(component.SoundInsert, revolverUid, user);
-            Popup(Loc.GetString("gun-revolver-insert"), revolverUid, user);
+            Audio.PlayPredicted(ent.Comp.SoundInsert, ent, user);
+            Popup(Loc.GetString("gun-revolver-insert"), ent, user);
             return true;
         }
 
         // Try to insert the entity directly.
-        for (var i = 0; i < component.Capacity; i++)
+        for (var i = 0; i < ent.Comp.Capacity; i++)
         {
-            var index = (component.CurrentIndex + i) % component.Capacity;
+            var index = (ent.Comp.CurrentIndex + i) % ent.Comp.Capacity;
 
-            if (component.AmmoSlots[index] != null ||
-                component.Chambers[index] != null)
+            if (ent.Comp.AmmoSlots[index] != null ||
+                ent.Comp.Chambers[index] != null)
             {
                 continue;
             }
 
-            component.AmmoSlots[index] = uid;
-            Containers.Insert(uid, component.AmmoContainer);
-            SetChamber(index, component, uid);
-            Audio.PlayPredicted(component.SoundInsert, revolverUid, user);
-            Popup(Loc.GetString("gun-revolver-insert"), revolverUid, user);
-            UpdateRevolverAppearance(revolverUid, component);
-            UpdateAmmoCount(revolverUid);
-            Dirty(revolverUid, component);
+            ent.Comp.AmmoSlots[index] = insertEnt;
+            Containers.Insert(insertEnt, ent.Comp.AmmoContainer);
+            SetChamber(ent, insertEnt, index);
+            Audio.PlayPredicted(ent.Comp.SoundInsert, ent, user);
+            Popup(Loc.GetString("gun-revolver-insert"), ent, user);
+            UpdateRevolverAppearance(ent);
+            UpdateAmmoCount(ent);
+            Dirty(ent);
             return true;
         }
 
-        Popup(Loc.GetString("gun-revolver-full"), revolverUid, user);
+        Popup(Loc.GetString("gun-revolver-full"), ent, user);
         return false;
     }
 
-    private void SetChamber(int index, RevolverAmmoProviderComponent component, EntityUid uid)
+    private void SetChamber(Entity<RevolverAmmoProviderComponent> ent, Entity<CartridgeAmmoComponent?> ammo, int index)
     {
-        if (TryComp<CartridgeAmmoComponent>(uid, out var cartridge) && cartridge.Spent)
+        if (!Resolve(ammo, ref ammo.Comp, false) || ammo.Comp.Spent)
         {
-            component.Chambers[index] = false;
+            ent.Comp.Chambers[index] = false;
             return;
         }
 
-        component.Chambers[index] = true;
+        ent.Comp.Chambers[index] = true;
     }
 
     private void OnRevolverVerbs(EntityUid uid, RevolverAmmoProviderComponent component, GetVerbsEvent<AlternativeVerb> args)
@@ -213,7 +213,7 @@ public partial class SharedGunSystem
         {
             Text = Loc.GetString("gun-revolver-empty"),
             Disabled = !AnyRevolverCartridges(component),
-            Act = () => EmptyRevolver(uid, component, args.User),
+            Act = () => EmptyRevolver((uid, component), args.User),
             Priority = 1
         });
 
@@ -221,7 +221,7 @@ public partial class SharedGunSystem
         {
             Text = Loc.GetString("gun-revolver-spin"),
             // Category = VerbCategory.G,
-            Act = () => SpinRevolver(uid, component, args.User)
+            Act = () => SpinRevolver((uid, component), args.User)
         });
     }
 
@@ -281,15 +281,15 @@ public partial class SharedGunSystem
         return count;
     }
 
-    public void EmptyRevolver(EntityUid revolverUid, RevolverAmmoProviderComponent component, EntityUid? user = null)
+    public void EmptyRevolver(Entity<RevolverAmmoProviderComponent> ent, EntityUid? user = null)
     {
-        var mapCoordinates = TransformSystem.GetMapCoordinates(revolverUid);
+        var mapCoordinates = TransformSystem.GetMapCoordinates(ent);
         var anyEmpty = false;
 
-        for (var i = 0; i < component.Capacity; i++)
+        for (var i = 0; i < ent.Comp.Capacity; i++)
         {
-            var chamber = component.Chambers[i];
-            var slot = component.AmmoSlots[i];
+            var chamber = ent.Comp.Chambers[i];
+            var slot = ent.Comp.AmmoSlots[i];
 
             if (slot == null)
             {
@@ -299,22 +299,22 @@ public partial class SharedGunSystem
                 // Too lazy to make a new method don't sue me.
                 if (!_netManager.IsClient)
                 {
-                    var uid = Spawn(component.FillPrototype, mapCoordinates);
+                    var uid = Spawn(ent.Comp.FillPrototype, mapCoordinates);
 
                     if (TryComp<CartridgeAmmoComponent>(uid, out var cartridge))
-                        SetCartridgeSpent(uid, cartridge, !(bool) chamber);
+                        SetCartridgeSpent(uid, cartridge, !(bool)chamber);
 
                     EjectCartridge(uid);
                 }
 
-                component.Chambers[i] = null;
+                ent.Comp.Chambers[i] = null;
                 anyEmpty = true;
             }
             else
             {
-                component.AmmoSlots[i] = null;
-                Containers.Remove(slot.Value, component.AmmoContainer);
-                component.Chambers[i] = null;
+                ent.Comp.AmmoSlots[i] = null;
+                Containers.Remove(slot.Value, ent.Comp.AmmoContainer);
+                ent.Comp.Chambers[i] = null;
 
                 if (!_netManager.IsClient)
                     EjectCartridge(slot.Value);
@@ -325,47 +325,47 @@ public partial class SharedGunSystem
 
         if (anyEmpty)
         {
-            Audio.PlayPredicted(component.SoundEject, revolverUid, user);
-            UpdateAmmoCount(revolverUid, prediction: false);
-            UpdateRevolverAppearance(revolverUid, component);
-            Dirty(revolverUid, component);
+            Audio.PlayPredicted(ent.Comp.SoundEject, ent, user);
+            UpdateAmmoCount(ent, prediction: false);
+            UpdateRevolverAppearance(ent);
+            Dirty(ent);
         }
     }
 
-    private void UpdateRevolverAppearance(EntityUid uid, RevolverAmmoProviderComponent component)
+    private void UpdateRevolverAppearance(Entity<RevolverAmmoProviderComponent> ent)
     {
-        if (!TryComp<AppearanceComponent>(uid, out var appearance))
+        if (!TryComp<AppearanceComponent>(ent, out var appearance))
             return;
 
-        var count = GetRevolverCount(component);
-        Appearance.SetData(uid, AmmoVisuals.HasAmmo, count != 0, appearance);
-        Appearance.SetData(uid, AmmoVisuals.AmmoCount, count, appearance);
-        Appearance.SetData(uid, AmmoVisuals.AmmoMax, component.Capacity, appearance);
+        var count = GetRevolverCount(ent.Comp);
+        Appearance.SetData(ent, AmmoVisuals.HasAmmo, count != 0, appearance);
+        Appearance.SetData(ent, AmmoVisuals.AmmoCount, count, appearance);
+        Appearance.SetData(ent, AmmoVisuals.AmmoMax, ent.Comp.Capacity, appearance);
     }
 
-    protected virtual void SpinRevolver(EntityUid revolverUid, RevolverAmmoProviderComponent component, EntityUid? user = null)
+    protected virtual void SpinRevolver(Entity<RevolverAmmoProviderComponent> ent, EntityUid? user = null)
     {
-        Audio.PlayPredicted(component.SoundSpin, revolverUid, user);
-        Popup(Loc.GetString("gun-revolver-spun"), revolverUid, user);
+        Audio.PlayPredicted(ent.Comp.SoundSpin, ent, user);
+        Popup(Loc.GetString("gun-revolver-spun"), ent, user);
     }
 
-    private void OnRevolverTakeAmmo(EntityUid uid, RevolverAmmoProviderComponent component, TakeAmmoEvent args)
+    private void OnRevolverTakeAmmo(Entity<RevolverAmmoProviderComponent> ent, ref TakeAmmoEvent args)
     {
-        var currentIndex = component.CurrentIndex;
-        Cycle(component, args.Shots);
+        var currentIndex = ent.Comp.CurrentIndex;
+        Cycle(ent.Comp, args.Shots);
 
         // Revolvers provide the bullets themselves rather than the cartridges so they stay in the revolver.
         for (var i = 0; i < args.Shots; i++)
         {
-            var index = (currentIndex + i) % component.Capacity;
-            var chamber = component.Chambers[index];
-            EntityUid? ent = null;
+            var index = (currentIndex + i) % ent.Comp.Capacity;
+            var chamber = ent.Comp.Chambers[index];
+            EntityUid? ammoEnt = null;
 
             // Get contained entity if it exists.
-            if (component.AmmoSlots[index] != null)
+            if (ent.Comp.AmmoSlots[index] != null)
             {
-                ent = component.AmmoSlots[index]!;
-                component.Chambers[index] = false;
+                ammoEnt = ent.Comp.AmmoSlots[index]!;
+                ent.Comp.Chambers[index] = false;
             }
             // Try to spawn a round if it's available.
             else if (chamber != null)
@@ -373,55 +373,55 @@ public partial class SharedGunSystem
                 if (chamber == true)
                 {
                     // Pretend it's always been there.
-                    ent = Spawn(component.FillPrototype, args.Coordinates);
+                    ammoEnt = Spawn(ent.Comp.FillPrototype, args.Coordinates);
 
                     if (!_netManager.IsClient)
                     {
-                        component.AmmoSlots[index] = ent;
-                        Containers.Insert(ent.Value, component.AmmoContainer);
+                        ent.Comp.AmmoSlots[index] = ammoEnt;
+                        Containers.Insert(ammoEnt.Value, ent.Comp.AmmoContainer);
                     }
 
-                    component.Chambers[index] = false;
+                    ent.Comp.Chambers[index] = false;
                 }
             }
 
             // Chamber empty or spent
-            if (ent == null)
+            if (ammoEnt == null)
                 continue;
 
-            if (TryComp<CartridgeAmmoComponent>(ent, out var cartridge))
+            if (TryComp<CartridgeAmmoComponent>(ammoEnt, out var cartridge))
             {
                 if (cartridge.Spent)
                     continue;
 
                 // Mark cartridge as spent and if it's caseless delete from the chamber slot.
-                SetCartridgeSpent(ent.Value, cartridge, true);
+                SetCartridgeSpent(ammoEnt.Value, cartridge, true);
                 var spawned = Spawn(cartridge.Prototype, args.Coordinates);
                 args.Ammo.Add((spawned, EnsureComp<AmmoComponent>(spawned)));
 
                 if (cartridge.DeleteOnSpawn)
                 {
-                    component.AmmoSlots[index] = null;
-                    component.Chambers[index] = null;
+                    ent.Comp.AmmoSlots[index] = null;
+                    ent.Comp.Chambers[index] = null;
                 }
             }
             else
             {
-                component.AmmoSlots[index] = null;
-                component.Chambers[index] = null;
-                args.Ammo.Add((ent.Value, EnsureComp<AmmoComponent>(ent.Value)));
+                ent.Comp.AmmoSlots[index] = null;
+                ent.Comp.Chambers[index] = null;
+                args.Ammo.Add((ammoEnt.Value, EnsureComp<AmmoComponent>(ammoEnt.Value)));
             }
 
             // Delete the cartridge entity on client
             if (_netManager.IsClient)
             {
-                QueueDel(ent);
+                QueueDel(ammoEnt);
             }
         }
 
-        UpdateAmmoCount(uid, prediction: false);
-        UpdateRevolverAppearance(uid, component);
-        Dirty(uid, component);
+        UpdateAmmoCount(ent, prediction: false);
+        UpdateRevolverAppearance(ent);
+        Dirty(ent);
     }
 
     private void Cycle(RevolverAmmoProviderComponent component, int count = 1)
@@ -429,34 +429,34 @@ public partial class SharedGunSystem
         component.CurrentIndex = (component.CurrentIndex + count) % component.Capacity;
     }
 
-    private void OnRevolverInit(EntityUid uid, RevolverAmmoProviderComponent component, ComponentInit args)
+    private void OnRevolverInit(Entity<RevolverAmmoProviderComponent> ent, ref ComponentInit args)
     {
-        component.AmmoContainer = Containers.EnsureContainer<Container>(uid, RevolverContainer);
-        component.AmmoSlots.EnsureCapacity(component.Capacity);
-        var remainder = component.Capacity - component.AmmoSlots.Count;
+        ent.Comp.AmmoContainer = Containers.EnsureContainer<Container>(ent, RevolverContainer);
+        ent.Comp.AmmoSlots.EnsureCapacity(ent.Comp.Capacity);
+        var remainder = ent.Comp.Capacity - ent.Comp.AmmoSlots.Count;
 
         for (var i = 0; i < remainder; i++)
         {
-            component.AmmoSlots.Add(null);
+            ent.Comp.AmmoSlots.Add(null);
         }
 
-        component.Chambers = new bool?[component.Capacity];
+        ent.Comp.Chambers = new bool?[ent.Comp.Capacity];
 
-        if (component.FillPrototype != null)
+        if (ent.Comp.FillPrototype != null)
         {
-            for (var i = 0; i < component.Capacity; i++)
+            for (var i = 0; i < ent.Comp.Capacity; i++)
             {
-                if (component.AmmoSlots[i] != null)
+                if (ent.Comp.AmmoSlots[i] != null)
                 {
-                    component.Chambers[i] = null;
+                    ent.Comp.Chambers[i] = null;
                     continue;
                 }
 
-                component.Chambers[i] = true;
+                ent.Comp.Chambers[i] = true;
             }
         }
 
-        DebugTools.Assert(component.AmmoSlots.Count == component.Capacity);
+        DebugTools.Assert(ent.Comp.AmmoSlots.Count == ent.Comp.Capacity);
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Solution.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Solution.cs
@@ -13,9 +13,9 @@ public partial class SharedGunSystem
         SubscribeLocalEvent<SolutionAmmoProviderComponent, GetAmmoCountEvent>(OnSolutionAmmoCount);
     }
 
-    private void OnSolutionTakeAmmo(EntityUid uid, SolutionAmmoProviderComponent component, TakeAmmoEvent args)
+    private void OnSolutionTakeAmmo(Entity<SolutionAmmoProviderComponent> ent, ref TakeAmmoEvent args)
     {
-        var shots = Math.Min(args.Shots, component.Shots);
+        var shots = Math.Min(args.Shots, ent.Comp.Shots);
 
         // Don't dirty if it's an empty fire.
         if (shots == 0)
@@ -23,38 +23,35 @@ public partial class SharedGunSystem
 
         for (var i = 0; i < shots; i++)
         {
-            args.Ammo.Add(GetSolutionShot(uid, component, args.Coordinates));
-            component.Shots--;
+            args.Ammo.Add(GetSolutionShot(ent, args.Coordinates));
+            ent.Comp.Shots--;
         }
 
-        UpdateSolutionShots(uid, component);
-        UpdateSolutionAppearance(uid, component);
+        UpdateSolutionShots(ent);
+        UpdateSolutionAppearance(ent);
     }
 
-    private void OnSolutionAmmoCount(EntityUid uid, SolutionAmmoProviderComponent component, ref GetAmmoCountEvent args)
+    private void OnSolutionAmmoCount(Entity<SolutionAmmoProviderComponent> ent, ref GetAmmoCountEvent args)
     {
-        args.Count = component.Shots;
-        args.Capacity = component.MaxShots;
+        args.Count = ent.Comp.Shots;
+        args.Capacity = ent.Comp.MaxShots;
     }
 
-    protected virtual void UpdateSolutionShots(EntityUid uid, SolutionAmmoProviderComponent component, Solution? solution = null)
-    {
+    protected virtual void UpdateSolutionShots(Entity<SolutionAmmoProviderComponent> ent, Solution? solution = null) { }
 
+    protected virtual (EntityUid Entity, IShootable) GetSolutionShot(Entity<SolutionAmmoProviderComponent> ent, EntityCoordinates position)
+    {
+        var shot = Spawn(ent.Comp.Prototype, position);
+        return (shot, EnsureShootable(shot));
     }
 
-    protected virtual (EntityUid Entity, IShootable) GetSolutionShot(EntityUid uid, SolutionAmmoProviderComponent component, EntityCoordinates position)
+    protected void UpdateSolutionAppearance(Entity<SolutionAmmoProviderComponent> ent)
     {
-        var ent = Spawn(component.Prototype, position);
-        return (ent, EnsureShootable(ent));
-    }
-
-    protected void UpdateSolutionAppearance(EntityUid uid, SolutionAmmoProviderComponent component)
-    {
-        if (!TryComp<AppearanceComponent>(uid, out var appearance))
+        if (!TryComp<AppearanceComponent>(ent, out var appearance))
             return;
 
-        Appearance.SetData(uid, AmmoVisuals.HasAmmo, component.Shots != 0, appearance);
-        Appearance.SetData(uid, AmmoVisuals.AmmoCount, component.Shots, appearance);
-        Appearance.SetData(uid, AmmoVisuals.AmmoMax, component.MaxShots, appearance);
+        Appearance.SetData(ent, AmmoVisuals.HasAmmo, ent.Comp.Shots != 0, appearance);
+        Appearance.SetData(ent, AmmoVisuals.AmmoCount, ent.Comp.Shots, appearance);
+        Appearance.SetData(ent, AmmoVisuals.AmmoMax, ent.Comp.MaxShots, appearance);
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -158,6 +158,8 @@ public abstract partial class SharedGunSystem : EntitySystem
         gun.Comp.ShootCoordinates = GetCoordinates(msg.Coordinates);
         gun.Comp.Target = GetEntity(msg.Target);
         AttemptShoot(user.Value, gun);
+        if (msg.Continuous)
+            gun.Comp.ShotCounter = 0;
     }
 
     private void OnStopShootRequest(RequestStopShootEvent ev, EntitySessionEventArgs args)

--- a/Content.Shared/Weapons/Ranged/Systems/UseDelayOnShootSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/UseDelayOnShootSystem.cs
@@ -13,9 +13,9 @@ public sealed class UseDelayOnShootSystem : EntitySystem
         SubscribeLocalEvent<UseDelayOnShootComponent, GunShotEvent>(OnUseShoot);
     }
 
-    private void OnUseShoot(EntityUid uid, UseDelayOnShootComponent component, ref GunShotEvent args)
+    private void OnUseShoot(Entity<UseDelayOnShootComponent> ent, ref GunShotEvent args)
     {
-        if (TryComp(uid, out UseDelayComponent? useDelay))
-            _delay.TryResetDelay((uid, useDelay));
+        if (TryComp(ent, out UseDelayComponent? useDelay))
+            _delay.TryResetDelay((ent, useDelay));
     }
 }

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -109,6 +109,9 @@ ui-options-hud-layout = HUD layout:
 
 ## Controls menu
 
+ui-options-hold-to-attack-melee = Hold to attack (melee)
+ui-options-hold-to-attack-ranged = Hold to attack (ranged)
+
 ui-options-binds-reset-all = Reset ALL keybinds
 ui-options-binds-explanation = Click to change binding, right-click to clear
 ui-options-unbound = Unbound


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
Early merge of:
* space-wizards/space-station-14/pull/41966
* space-wizards/space-station-14/pull/42596

41966 was included to avoid having to change upstream code to work with an outdated codebase and then need to revert it later.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
i don't want a fucking rsi
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="815" height="465" alt="image" src="https://github.com/user-attachments/assets/50c5f6b2-7ccb-457f-812f-57352a80bd3d" />
yes those are my keybinds it's ok don't worry about it

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Copied from 41966:
> - Many instances of `EntityUid, Component` in `SharedGunSystem` and its inheritors have been updated to use `Entity<T>`. Please update your API accordingly.
> - `TryGetGun` now returns `Entity<GunComponent>` instead of `EntityUid`.
>- `SetChamber`'s parameters have been adjusted from `int, RevolverAmmoProviderComponent, EntityUid` to `Entity<RevolverAmmoProviderComponent>, Entity<CartridgeAmmoComponent>, int`.
> - `ChamberSlot` and `MagazineSlot` are now public consts in `SharedGunSystem`.

Code compiles without issue, no problems noticed in testing.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added an toggle for "hold-to-attack" under the accessibility tab.