### PR TITLE
allow multiple emotes with the same trigger word (from deltaV)

### DIFF
--- a/Content.Shared/Chat/SharedChatSystem.Emote.cs
+++ b/Content.Shared/Chat/SharedChatSystem.Emote.cs
@@ -1,23 +1,25 @@
-using System.Collections.Frozen;
 using Content.Shared._RMC14.Voicelines; // Harmony, RMC14
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Speech;
-using Robust.Shared.Player; // Harmony, RMC14
 using Robust.Shared.Audio;
+using Robust.Shared.Player; // Harmony, RMC14
 using Robust.Shared.Random;
+using System.Collections.Frozen;
+using System.Collections.Immutable; // DeltaV
+using System.Security.Cryptography;
 
 namespace Content.Shared.Chat;
 
 public abstract partial class SharedChatSystem
 {
-    private FrozenDictionary<string, EmotePrototype> _wordEmoteDict = FrozenDictionary<string, EmotePrototype>.Empty;
+    private FrozenDictionary<string, ImmutableList<EmotePrototype>> _wordEmoteDict = FrozenDictionary<string, ImmutableList<EmotePrototype>>.Empty; // DeltaV - Multiple emotes
 
     // Harmony, RMC14 - Mute Emotes Option
     [Dependency] private readonly HumanoidVoicelinesSystem _humanoidVoicelines = default!;
 
     private void CacheEmotes()
     {
-        var dict = new Dictionary<string, EmotePrototype>();
+        var dict = new Dictionary<string, ImmutableList<EmotePrototype>>(); // DeltaV - Multiple triggers for the same emote
         var emotes = _prototypeManager.EnumeratePrototypes<EmotePrototype>();
         foreach (var emote in emotes)
         {
@@ -26,12 +28,16 @@ public abstract partial class SharedChatSystem
                 var lowerWord = word.ToLower();
                 if (dict.TryGetValue(lowerWord, out var value))
                 {
-                    var errMsg = $"Duplicate of emote word {lowerWord} in emotes {emote.ID} and {value.ID}";
-                    Log.Error(errMsg);
+                    // Begin DeltaV modification - Multiple emotes for the same words
+                    dict[lowerWord] = value.Add(emote);
+
+                    var errMsg = $"Duplicate of emote word {lowerWord}";
+                    Log.Warning(errMsg);
+
                     continue;
                 }
 
-                dict.Add(lowerWord, emote);
+                dict.Add(lowerWord, ImmutableList.Create(emote)); // End DeltaV modification
             }
         }
 
@@ -180,13 +186,32 @@ public abstract partial class SharedChatSystem
     protected bool TryEmoteChatInput(EntityUid source, string textInput)
     {
         var actionTrimmedLower = TrimPunctuation(textInput.ToLower());
-        if (!_wordEmoteDict.TryGetValue(actionTrimmedLower, out var emote))
+        //Start Box Change - DV Refactor to allow multiple emotes for the same word trigger
+        //if (!_wordEmoteDict.TryGetValue(actionTrimmedLower, out var emote))
+        //    return true;
+
+        //if (!AllowedToUseEmote(source, emote))
+        //    return true;
+
+        //return TryInvokeEmoteEvent(source, emote);
+        if (!_wordEmoteDict.TryGetValue(actionTrimmedLower, out var emotes)) // DeltaV, renames to emotes
             return true;
 
-        if (!AllowedToUseEmote(source, emote))
-            return true;
+        var validEmote = false; // DeltaV - Multiple emotes for the same trigger
+        foreach (var emote in emotes)
+        {
+            if (!AllowedToUseEmote(source, emote))
+                continue;
 
-        return TryInvokeEmoteEvent(source, emote);
+            if (TryInvokeEmoteEvent(source, emote))
+            {
+                validEmote = true; // DeltaV
+                break; // Frontier: break on first emote (avoid playing multiple sounds at once)
+            }
+        }
+        //End Box Change
+
+        return validEmote;
 
     }
     /// <summary>


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
Refactors parts of Content.Shared/Chat/SharedChatSystem.Emote.cs to support multiple emotes with the same trigger word (for example felinids and vulpkanin both having "growl" emotes with different icons, sounds, etc). 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
required for harpies.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
