### PR TITLE
1984's the Golden Mask

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -174,7 +174,7 @@
   id: SalvageTreasureLegendary
   table: !type:GroupSelector
     children:
-    - id: ClothingMaskGoldenCursed
+#   - id: ClothingMaskGoldenCursed #Box Change - 1984's golden mask
     - id: ClothingHeadHatFancyCrown
     - id: GoldenBikeHorn
     - id: ClothingHeadHatCatEars


### PR DESCRIPTION
## About the PR
Removes the cursed golden mask from the salvage loot pools.
Item that just leads to rulebreaks, either through powergaming or self antagging.

## Why / Balance
admin headache item that I've been sniping off debris when i spot it. 

## Technical details
-1 line yaml change to commet out an entry in Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- remove: The golden mask no longer spawns in salvage lootpools.

