### PR TITLE
resize paper reams to 1x2 and add them as trinkets

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -49,6 +49,11 @@
   # End Box Change
   - BoxFolderPlasticClipboardThreePapers
   - BoxFolderClipboardThreePapers
+  # Start Box Change: Paper reams
+  - BoxReamWhite
+  - BoxReamClassic
+  - BoxReamBright
+  # End Box Change
   # Start Box Change - Starcup notebooks
   - NotebookPocketBlue
   - NotebookPocketBrown

--- a/Resources/Prototypes/_Box/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Box/Loadouts/Miscellaneous/trinkets.yml
@@ -247,3 +247,24 @@
   storage:
     back:
     - WhiteCane
+
+- type: loadout
+  id: BoxReamClassic
+  storage:
+    back:
+    - BoxReamClassic
+  groupBy: "folders"
+
+- type: loadout
+  id: BoxReamBright
+  storage:
+    back:
+    - BoxReamBright
+  groupBy: "folders"
+
+- type: loadout
+  id: BoxReamWhite
+  storage:
+    back:
+    - BoxReamWhite
+  groupBy: "folders"

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -233,6 +233,14 @@
     containers:
       storagebase: !type:Container
         ents: []
+  # Start Box Change: Resize to 1x2 and tag as folder (so it will fit in paperwork belts etc)
+  - type: Item
+    size: Small
+    shape: null
+  - type: Tag
+    tags:
+    - Folder
+  # End Box Change
   - type: Storage
     grid:
     - 0,0,3,5


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
Resizes paper reams to be a vertical 1x2 (the same as folders), tags them as folders (so they will fit in paperwork belts etc if/when we add those), and adds them as trinket options grouped with the rest of the folders.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More colorful writing options for mute characters.
Reams hold 4 more pieces of paper than a folder, *only* hold paper, and you can functionally get infinite paper by printing a blank .txt document from a fax machine anyways, so I really don't see any of this being a balance concern. 
## Technical details
<!-- Summary of code changes for easier review. -->

<img width="278" height="138" alt="Content Client_UIvacpEiw7" src="https://github.com/user-attachments/assets/750626f9-7eb2-4085-99c6-a8437c989ae2" />

<img width="798" height="797" alt="Content Client_h3SGdgQ1k6" src="https://github.com/user-attachments/assets/b97b04d8-18e9-4468-ab6c-b1c54784ed16" />

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Paper reams are now smaller and can be taken as loadout trinkets.
