### PR TITLE
fix boxer and zookeeper missing accessibility tab

### DIFF
--- a/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/role_loadouts.yml
@@ -9,6 +9,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Accessibility # Box Change - Add accessibility tab
   - ZookeeperJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -23,5 +24,6 @@
   - Glasses
   - Survival
   - Trinkets
+  - Accessibility # Box Change - Add accessibility tab
   - BoxerJobTrinkets
   - GroupSpeciesBreathTool


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
I missed these two when I added the tab so I'm fixing it now
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
two lines of yaml
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="798" height="411" alt="image" src="https://github.com/user-attachments/assets/ebe77873-9325-442b-a301-ede50d3f2b6e" />
<img width="827" height="402" alt="image" src="https://github.com/user-attachments/assets/0f84751c-234a-4707-a84b-671b68c1fa83" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Boxer and Zookeeper now have access to the Accessibility loadout tab

