### PR TITLE
[NuBody] Voice fix

### DIFF
--- a/Content.IntegrationTests/Tests/Humanoid/HumanoidProfileTests.cs
+++ b/Content.IntegrationTests/Tests/Humanoid/HumanoidProfileTests.cs
@@ -1,0 +1,49 @@
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Preferences;
+using Content.Shared.Speech.Components;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Humanoid;
+
+[TestFixture]
+[TestOf(typeof(HumanoidProfileSystem))]
+public sealed class HumanoidProfileTests
+{
+    private static readonly ProtoId<SpeciesPrototype> Vox = "Vox";
+
+    [Test]
+    public async Task EnsureValidLoading()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitIdleAsync();
+
+        await server.WaitAssertion(() =>
+        {
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var humanoidProfile = entityManager.System<HumanoidProfileSystem>();
+            var human = entityManager.Spawn("MobHuman");
+            humanoidProfile.ApplyProfileTo(human, new HumanoidCharacterProfile()
+                .WithSex(Sex.Female)
+                .WithAge(67)
+                .WithGender(Gender.Neuter)
+                .WithSpecies(Vox));
+            var humanoidComponent = entityManager.GetComponent<HumanoidProfileComponent>(human);
+            var voiceComponent = entityManager.GetComponent<VocalComponent>(human);
+
+            Assert.That(humanoidComponent.Age, Is.EqualTo(67));
+            Assert.That(humanoidComponent.Sex, Is.EqualTo(Sex.Female));
+            Assert.That(humanoidComponent.Gender, Is.EqualTo(Gender.Neuter));
+            Assert.That(humanoidComponent.Species, Is.EqualTo(Vox));
+
+            Assert.That(voiceComponent.Sounds, Is.Not.Null, message: "the MobHuman spawned by this test needs to have sex-specific sound set");
+            Assert.That(voiceComponent.Sounds![Sex.Female], Is.EqualTo(voiceComponent.EmoteSounds));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/Humanoid/HumanoidProfileSystem.cs
+++ b/Content.Shared/Humanoid/HumanoidProfileSystem.cs
@@ -30,6 +30,9 @@ public sealed class HumanoidProfileSystem : EntitySystem
         ent.Comp.Sex = profile.Sex;
         Dirty(ent);
 
+        var sexChanged = new SexChangedEvent(ent.Comp.Sex, profile.Sex);
+        RaiseLocalEvent(ent, ref sexChanged);
+
         if (TryComp<GrammarComponent>(ent, out var grammar))
         {
             _grammar.SetGender((ent, grammar), profile.Gender);

--- a/Content.Shared/Humanoid/Sex.cs
+++ b/Content.Shared/Humanoid/Sex.cs
@@ -17,5 +17,6 @@ namespace Content.Shared.Humanoid
     ///     Raised when entity has changed their sex.
     ///     This doesn't handle gender changes.
     /// </summary>
+    [ByRefEvent]
     public record struct SexChangedEvent(Sex OldSex, Sex NewSex);
 }


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
cherry-picks space-wizards/space-station-14/pull/42550
fixes characters not using the proper sex-based soundcollection (which resulted in female characters using male sounds)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
nubody broke it
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
