### PR TITLE
[NuBody] give avali and allulalo their survival boxes back

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -19,10 +19,10 @@
     - Moth
     - Reptilian
     - Vulpkanin
-    # - Avali # Latestation # Box - Readd after Nubody fixes
+    - Avali # Latestation
     # - Rodentia # Box Change - Adds Rodentia # Box - Readd after Nubody fixes
     # - Thaven #Box Change - Add Thaven # Box - Readd after Nubody fixes
-    # - Allulalo # Box Change - Add Allulalo # Box - Readd after Nubody fixes
+    - Allulalo # Box Change - Add Allulalo
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
uncomments allulalo and avalli from the OxygenBreather loadout effect group, because we missed them when the prs were made
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
breathing is good
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
