### PR TITLE
[delta-v port] tape recorder improvements

### DIFF
--- a/Content.Shared/_DV/TapeRecorder/Components/TapeRecorderComponent.cs
+++ b/Content.Shared/_DV/TapeRecorder/Components/TapeRecorderComponent.cs
@@ -1,4 +1,6 @@
 using Content.Shared._DV.TapeRecorder.Systems;
+using Content.Shared._DV.DeviceLinking.Systems;
+using Content.Shared.DeviceLinking;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -80,4 +82,20 @@ public sealed partial class TapeRecorderComponent : Component
     {
         Params = AudioParams.Default.WithVolume(-2f).WithMaxDistance(3f)
     };
+
+    /// <summary>
+    /// Ports for signal control
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> PausePort = "Pause";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> RecordPort = "Record";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> PlaybackPort = "Playback";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> RewindPort = "Rewind";
+
 }

--- a/Content.Shared/_DV/TapeRecorder/Components/TapeRecorderComponent.cs
+++ b/Content.Shared/_DV/TapeRecorder/Components/TapeRecorderComponent.cs
@@ -1,5 +1,5 @@
 using Content.Shared._DV.TapeRecorder.Systems;
-using Content.Shared._DV.DeviceLinking.Systems;
+//using Content.Shared._DV.DeviceLinking.Systems; // Box Change: Why was this even here?
 using Content.Shared.DeviceLinking;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;

--- a/Content.Shared/_DV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
+++ b/Content.Shared/_DV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.Tag;
 using Content.Shared.Toggleable;
 using Content.Shared.UserInterface;
 using Content.Shared.Whitelist;
+using Content.Shared.DeviceLinking;
+using Content.Shared.DeviceLinking.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
@@ -46,6 +48,7 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
         SubscribeLocalEvent<TapeRecorderComponent, ExaminedEvent>(OnRecorderExamined);
         SubscribeLocalEvent<TapeRecorderComponent, ChangeModeTapeRecorderMessage>(OnChangeModeMessage);
         SubscribeLocalEvent<TapeRecorderComponent, AfterActivatableUIOpenEvent>(OnUIOpened);
+        SubscribeLocalEvent<TapeRecorderComponent, SignalReceivedEvent>(OnSignalReceived);
 
         SubscribeLocalEvent<TapeCassetteComponent, ExaminedEvent>(OnTapeExamined);
         SubscribeLocalEvent<TapeCassetteComponent, DamageChangedEvent>(OnDamagedChanged);
@@ -413,6 +416,26 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
             cooldown);
 
         _ui.SetUiState(uid, TapeRecorderUIKey.Key, state);
+    }
+
+    private void OnSignalReceived(Entity<TapeRecorderComponent> ent, ref SignalReceivedEvent args)
+    {
+        if (args.Port == ent.Comp.PausePort)
+        {
+            SetMode(ent, TapeRecorderMode.Stopped);
+        }
+        else if (args.Port == ent.Comp.RecordPort)
+        {
+            SetMode(ent, TapeRecorderMode.Recording);
+        }
+        else if (args.Port == ent.Comp.PlaybackPort)
+        {
+            SetMode(ent, TapeRecorderMode.Playing);
+        }
+        else if (args.Port == ent.Comp.RewindPort)
+        {
+            SetMode(ent, TapeRecorderMode.Rewinding);
+        }
     }
 }
 

--- a/Resources/Locale/en-US/_DV/linkports/link-ports.ftl
+++ b/Resources/Locale/en-US/_DV/linkports/link-ports.ftl
@@ -1,0 +1,7 @@
+signal-port-name-power-toggle = Toggle Power
+signal-port-description-power-toggle = A signal port, that toggles power state when it recieves a signal.
+
+signal-port-description-playback = Start audio playback.
+signal-port-description-record = Start recording audio.
+signal-port-description-rewind = Rewind audio.
+signal-port-description-pause = Stop playing, recording, or rewinding.

--- a/Resources/Prototypes/_DV/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/_DV/DeviceLinking/sink_ports.yml
@@ -1,0 +1,24 @@
+- type: sinkPort
+  id: PowerToggle
+  name: signal-port-name-power-toggle
+  description: signal-port-description-power-toggle
+
+- type: sinkPort
+  id: Pause
+  name: tape-recorder-menu-stopped-button
+  description: signal-port-description-pause
+
+- type: sinkPort
+  id: Record
+  name: tape-recorder-menu-recording-button
+  description: signal-port-description-record
+
+- type: sinkPort
+  id: Playback
+  name: tape-recorder-menu-playing-button
+  description: signal-port-description-playback
+
+- type: sinkPort
+  id: Rewind
+  name: tape-recorder-menu-rewinding-button
+  description: signal-port-description-rewind

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -50,6 +50,17 @@
     interfaces:
       enum.TapeRecorderUIKey.Key:
         type: TapeRecorderBoundUserInterface
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - Pause
+    - Record
+    - Playback
+    - Rewind
 
 - type: entity
   parent: TapeRecorder

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -16,6 +16,10 @@
   - type: TapeRecorder
   - type: ActiveListener
     range: 4
+  - type: ChangeVoiceInContainer
+    whitelist:
+      components:
+      - SecretStash
   - type: UseDelay
     delay: 1
   - type: Speech


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
cherry-picks:
- DeltaV-Station/Delta-v/pull/4437
- DeltaV-Station/Delta-v/pull/5629

tape recorders can now be linked to signal senders (i.e. buttons, remote signalers) to remotely control their operation, and will change their voice name if inserted into a plushie (like pAIs, MMIs, and posibrains)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fun
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/5766da13-44cc-464a-a8ce-ed2c6633320c

https://github.com/user-attachments/assets/1312fb38-e355-4895-b058-740374466561

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Tape recorders can now be controlled using four signal ports corresponding to their buttons.
- tweak: Tape recorders now change their voice when hidden in plushies, toilets, or plants.