### PR TITLE
Doubles Flavor Text Examine Range (3 --> 6 tiles)

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -40,7 +40,7 @@ namespace Content.Shared.Examine
         public const float DeadExamineRange = 0.75f;
 
         public const float ExamineRange = 16f;
-        protected const float ExamineDetailsRange = 3f;
+        protected const float ExamineDetailsRange = 6f; //Box Change - increases description examine range from 3 --> 6 tiles
 
         protected const float ExamineBlurrinessMult = 2.5f;
 


### PR DESCRIPTION
## About the PR
Very simple PR.
doubles the range at which you can read someones description without affecting any other examine text.
Helpful for RP purposes but cant really be used to metagame.
6 Tiles means that at default screen zoom, if someones on your screen, and you're on theres, you can examine eachother.

## Why / Balance
see above.

## Technical details
change one float value from 3 to 6 in Content.Shared/Examine/ExamineSystemShared.cs

## Media
Old range of examination is highlighted in red.
New range is highlighted in light blue (and also demonstrated by how far i am from the character im examining)

<img width="508" height="513" alt="image" src="https://github.com/user-attachments/assets/2d96f67b-ce19-4a55-ada4-530ebde43f3f" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**

