### PR TITLE
remove alerts for passive vent critter spawns

### DIFF
--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -48,8 +48,10 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
             return;
 
         var nearest = beacon?.Comp?.Text!;
-        Comp<StationEventComponent>(uid).StartAnnouncement = Loc.GetString("station-event-vent-creatures-start-announcement-deltav", ("location", nearest));
-
+        // Start Box Change: Don't send an announcement if StartAnnouncement is null
+        if (Comp<StationEventComponent>(uid).StartAnnouncement != null)
+            Comp<StationEventComponent>(uid).StartAnnouncement = Loc.GetString("station-event-vent-creatures-start-announcement-deltav", ("location", nearest));
+        // End Box Change
         base.Added(uid, comp, gameRule, args);
     }
 

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -22,9 +22,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
+    # Start Box Change: Remove announcement for nonhostile vent critters
+    #startAnnouncement: station-event-vent-creatures-start-announcement
+    #startAudio:
+    #  path: /Audio/Announcements/attention.ogg
+    # End Box Change
     earliestStart: 15
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
@@ -42,9 +44,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
+    # Start Box Change: Remove announcement for nonhostile vent critters
+    #startAnnouncement: station-event-vent-creatures-start-announcement
+    #startAudio:
+    #  path: /Audio/Announcements/attention.ogg
+    # End Box Change
     earliestStart: 15
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
@@ -65,9 +69,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
+    # Start Box Change: Remove announcement for nonhostile vent critters
+    #startAnnouncement: station-event-vent-creatures-start-announcement
+    #startAudio:
+    #  path: /Audio/Announcements/attention.ogg
+    # End Box Change
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
   - type: VentCrittersRule
@@ -85,9 +91,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
+    # Start Box Change: Remove announcement for nonhostile vent critters
+    #startAnnouncement: station-event-vent-creatures-start-announcement
+    #startAudio:
+    #  path: /Audio/Announcements/attention.ogg
+    # End Box Change
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
   - type: VentCrittersRule
@@ -102,9 +110,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
+    # Start Box Change: Remove announcement for nonhostile vent critters
+    #startAnnouncement: station-event-vent-creatures-start-announcement
+    #startAudio:
+    #  path: /Audio/Announcements/attention.ogg
+    # End Box Change
     earliestStart: 15
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
removes alert messages/sounds for passive vent critter spawns (mice/cockroaches/snails)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
admin request
## Technical details
<!-- Summary of code changes for easier review. -->
comments out some yaml
delta-v vent critter system hardcoded the announcement so i added a check to not send an announcement if the gamerule doesn't have one defined
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/c24cd185-f234-41cd-ab63-ab8312b0a525

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Passive vent spawns (mice/roaches/snails) will no longer come with an announcement. If you see a warning about vent critters, take it seriously!
