### PR TITLE
Adds Handheld Crew Monitor to Paramedic Locker & Removes CMO objective

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -130,6 +130,7 @@
     - id: ClothingHeadsetMedical
     - id: ClothingMaskSterile
     - id: HandheldGPSBasic
+    - id: HandheldCrewMonitor # Box change - Paramedic gets the handheld crew monitor.
     - id: MedkitFilled
       prob: 0.3
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -1,7 +1,8 @@
 - type: entity
   name: handheld crew monitor
   categories: [ DoNotMap ]
-  parent: [ BaseHandheldComputer, BaseGrandTheftContraband ]
+#  parent: [ BaseHandheldComputer, BaseGrandTheftContraband ] # Box Change - comments out to remove grand theft parent
+  parent: [ BaseHandheldComputer] #Box Change - New Parent list
   # CMO-only bud, don't add more.
   id: HandheldCrewMonitor
   description: A hand-held crew monitor displaying the status of suit sensors.
@@ -26,11 +27,13 @@
   - type: StationLimitedNetwork
   - type: StaticPrice
     price: 500
-  - type: Tag
-    tags:
-    - HighRiskItem
-  - type: StealTarget
-    stealGroup: HandheldCrewMonitor
+# Box Change Start - removes antag objective and high risk tag
+#  - type: Tag
+#    tags:
+#    - HighRiskItem
+#  - type: StealTarget
+#    stealGroup: HandheldCrewMonitor
+# Box Change End - removes antag objective and high risk tag
 
 - type: entity
   id: HandheldCrewMonitorEmpty

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -12,7 +12,7 @@
   weights:
     CaptainIDStealObjective: 1
     CMOHyposprayStealObjective: 1
-    CMOCrewMonitorStealObjective: 1
+#    CMOCrewMonitorStealObjective: 1 #Box Change - REmoves CMO Crew Monitor Objetive
     RDHardsuitStealObjective: 1
     NukeDiskStealObjective: 1
     MagbootsStealObjective: 1

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -7,12 +7,14 @@
     sprite: Objects/Specific/Medical/hypospray.rsi
     state: hypo
 
-- type: stealTargetGroup
-  id: HandheldCrewMonitor
-  name: steal-target-groups-handheld-crew-monitor
-  sprite:
-    sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi
-    state: scanner
+# Box Change Start- removes handheld crew monitor objective.
+# - type: stealTargetGroup
+#   id: HandheldCrewMonitor
+#   name: steal-target-groups-handheld-crew-monitor
+#   sprite:
+#     sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi
+#     state: scanner
+# Box Change End - removes handheld crew monitor objective.
 
 - type: stealTargetGroup
   id: ClothingOuterHardsuitRd

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -213,12 +213,14 @@
   - type: StealCondition
     stealGroup: Hypospray
 
-- type: entity
-  parent: BaseCMOStealObjective
-  id: CMOCrewMonitorStealObjective
-  components:
-  - type: StealCondition
-    stealGroup: HandheldCrewMonitor
+#Box Change Start - Removes handheld crew monitor objective
+# - type: entity
+#   parent: BaseCMOStealObjective
+#   id: CMOCrewMonitorStealObjective
+#   components:
+#   - type: StealCondition
+#     stealGroup: HandheldCrewMonitor
+# Box Change End - Removes handheld crew monitor objective
 
 ## rd
 

--- a/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
@@ -91,9 +91,11 @@
   parent: [BaseBloodBrotherObjective, CMOHyposprayStealObjective]
   id: BloodBrotherCMOHyposprayStealObjective
 
-- type: entity
-  parent: [BaseBloodBrotherObjective, CMOCrewMonitorStealObjective]
-  id: BloodBrotherCMOCrewMonitorStealObjective
+# Box Change Start - Removes crew monitor objective
+# - type: entity
+#   parent: [BaseBloodBrotherObjective, CMOCrewMonitorStealObjective]
+#   id: BloodBrotherCMOCrewMonitorStealObjective
+# Box Change End - Removes crew monitor objective
 
 ## rd
 

--- a/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
@@ -18,7 +18,7 @@
   weights:
     BloodBrotherCaptainIDStealObjective: 1
     BloodBrotherCMOHyposprayStealObjective: 1
-    BloodBrotherCMOCrewMonitorStealObjective: 1
+#   BloodBrotherCMOCrewMonitorStealObjective: 1 # Box Change - Removes crew mon objective
     BloodBrotherRDHardsuitStealObjective: 1
     BloodBrotherNukeDiskStealObjective: 1
     BloodBrotherMagbootsStealObjective: 1


### PR DESCRIPTION

## About the PR
Adds a copy of the handheld crew monitor to the paramedics locker.
Removes the syndicate traitor objective targeting the handheld crew monitor.
I chose not to alter the goggles to be the target instead, as these are already a thief objective, and i want to discourage traitor objective overlap wherever I can to prevent frustration (uh oh traitor, the goggles are in a thief den in space, sad!)

## Why / Balance
You can find the discussion for this here, but in short:
https://discord.com/channels/1406523997306359848/1531645284604444765

I'd like for paramedics to be able to engage with the game more rather than sitting in medical all round. But, I dont want to cause issues where an antagonist has to guess who has the crew monitor - the paramedic, or the CMO.


## Technical details
-adds the prototype to the fill menu Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
-comments out objective code in various places
Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
Resources/Prototypes/Objectives/objectiveGroups.yml
Resources/Prototypes/Objectives/stealTargetGroups.yml
Resources/Prototypes/Objectives/traitor.yml


## Media
<img width="488" height="411" alt="image" src="https://github.com/user-attachments/assets/4dd4b444-0268-4436-b0a4-38aa802ad357" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- add: The Paramedic now starts with a handheld crew monitor of their own.
- remove: The Syndicate Agent "steal the handheld crewmonitor" objective has been disabled from rolling.

