### PR TITLE
[Hotfix] Adds missing Passenger Bomber Jackets

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -355,6 +355,10 @@
   - LongcoatBrown
   - LongcoatNanoTrasen
   # Box End - Passenger long coats
+  # Box Start - Imp Bomber Jackets
+  - BomberBlack
+  - BomberWhite
+  #Box End - Imp Bomber Jackets
 
 - type: loadoutGroup
   id: PassengerShoes


### PR DESCRIPTION
## About the PR
whoops

## Why / Balance
missing content.

## Technical details
-adds two entries to Resources/Prototypes/Loadouts/loadout_groups.yml

## Media
<img width="1780" height="744" alt="image" src="https://github.com/user-attachments/assets/f24125da-a508-4a50-bf52-64b84b567c1e" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Adds missing bomberjackets to the entries.

