### PR TITLE
species muting fixes and cleanup

### DIFF
--- a/Content.Shared/_Box/Audio/SpeciesMutingSystem.cs
+++ b/Content.Shared/_Box/Audio/SpeciesMutingSystem.cs
@@ -12,6 +12,9 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Box.Audio;
 
+/// <summary>
+/// System for muting speech, emote, and interaction sounds based on user options.
+/// </summary>
 public sealed class SpeciesMutingSystem : EntitySystem
 {
     [Dependency] private readonly INetConfigurationManager _config = default!;
@@ -48,6 +51,9 @@ public sealed class SpeciesMutingSystem : EntitySystem
     private static readonly HashSet<ProtoId<EmoteSoundsPrototype>> ThavenEmotes = ["MaleThaven"];
     private static readonly HashSet<ProtoId<EmoteSoundsPrototype>> AllulaloEmotes = ["Allulalo"];
 
+    /// <summary>
+    /// A collection of speech sounds to mute, and their associated CVar.
+    /// </summary>
     private readonly Dictionary<ProtoId<SpeechSoundsPrototype>, CVarDef> _voicelineCVars = new()
     {
         [ArachnidVoice] = RMCCVars.RMCPlayVoicelinesArachnid,
@@ -65,6 +71,9 @@ public sealed class SpeciesMutingSystem : EntitySystem
         [AllulaloVoice] = RMCCVars.RMCPlayVoicelinesAllulalo,
     };
 
+    /// <summary>
+    /// A collection of emote sound prototypes to mute, and their associated CVar.
+    /// </summary>
     private readonly Dictionary<HashSet<ProtoId<EmoteSoundsPrototype>>, CVarDef> _emoteCVars = new()
     {
         [ArachnidEmotes] = RMCCVars.RMCPlayEmotesArachnid,
@@ -84,9 +93,24 @@ public sealed class SpeciesMutingSystem : EntitySystem
         [AllulaloEmotes] = RMCCVars.RMCPlayEmotesAllulalo,
     };
 
-    private readonly Dictionary<HashSet<String>, CVarDef> _interactCVars = new()
+    /// <summary>
+    /// A collection of interact sounds (specified as sound paths) to mute, and their associated CVar.
+    /// Copy the path used in the offending entity's yml to ensure accuracy.
+    /// </summary>
+    private readonly Dictionary<HashSet<String>, CVarDef> _interactPathCVars = new()
     {
         [["/Audio/Animals/wawa_chatter.ogg", "/Audio/Animals/wawa_chillin.ogg"]] = RMCCVars.RMCPlayEmotesScurret
+    };
+
+    /// <summary>
+    /// A collection of interact sounds (specified as sound collections) to mute, and their associated CVar.
+    /// </summary>
+    private readonly Dictionary<HashSet<ProtoId<SoundCollectionPrototype>>, CVarDef> _interactCollectionCVars = new()
+    {
+        // Nothing here for now.
+        // Example line will cause the desk bell to have its interact sounds muted if human emotes are muted.
+        // In memory of the first round with the new system where we found out I broke the desk bell due to casting issues.
+        //[["DeskBell"]] = RMCCVars.RMCPlayEmotesHuman
     };
 
     private EntityQuery<VocalComponent> _vocalQuery;
@@ -104,19 +128,14 @@ public sealed class SpeciesMutingSystem : EntitySystem
     {
         if (forPlayer.AttachedEntity == vocalizer &&
             !_config.GetClientCVar(forPlayer.Channel, RMCCVars.RMCPlayEmotesYourself))
-        {
             return false;
-        }
 
         if (!_vocalQuery.Resolve(vocalizer, ref vocalizer.Comp, false))
-        {
             return true;
-        }
 
         if (vocalizer.Comp.EmoteSounds == null)
-        {
             return true;
-        }
+
         ProtoId<EmoteSoundsPrototype> sound = (ProtoId<EmoteSoundsPrototype>)vocalizer.Comp.EmoteSounds;
         CVarDef? play = null;
         foreach (var emote in _emoteCVars)
@@ -127,10 +146,10 @@ public sealed class SpeciesMutingSystem : EntitySystem
                 break;
             }
         }
+
         if (play == null)
-        {
             return true;
-        }
+
         return _config.GetClientCVar<bool>(forPlayer.Channel, play.Name);
     }
 
@@ -138,59 +157,75 @@ public sealed class SpeciesMutingSystem : EntitySystem
     {
         if (forPlayer.AttachedEntity == vocalizer &&
             !_config.GetClientCVar(forPlayer.Channel, RMCCVars.RMCPlayVoicelinesYourself))
-        {
             return false;
-        }
 
         if (!_speechQuery.Resolve(vocalizer, ref vocalizer.Comp, false) ||
             !_voicelineCVars.TryGetValue(vocalizer.Comp.SpeechSounds ?? HumanVoice, out var play))
-        {
             return true;
-        }
 
         return _config.GetClientCVar<bool>(forPlayer.Channel, play.Name);
     }
+
     public bool ShouldPlayInteractionPopup(Entity<InteractionPopupComponent?> vocalizer, ICommonSession forPlayer)
     {
         if (forPlayer.AttachedEntity == vocalizer &&
             !_config.GetClientCVar(forPlayer.Channel, RMCCVars.RMCPlayEmotesYourself))
-        {
             return false;
-        }
+
         if (!_interactionQuery.Resolve(vocalizer, ref vocalizer.Comp, false))
-        {
             return true;
-        }
-        string? path1 = null;
-        string? path2 = null;
+
+        HashSet<string> paths = [];
+        HashSet<ProtoId<SoundCollectionPrototype>> collections = [];
         CVarDef? play = null;
+
+        //Evil type conversion section because interact sounds aren't standardized as collections
         if (vocalizer.Comp.InteractSuccessSound != null)
         {
-            var x = (SoundPathSpecifier)vocalizer.Comp.InteractSuccessSound;
-            path1 = x.Path.ToString();
+            if (vocalizer.Comp.InteractSuccessSound is SoundCollectionSpecifier specifier &&
+                specifier.Collection != null)
+            {
+                collections.Add(specifier.Collection);
+            }
+            if (vocalizer.Comp.InteractFailureSound is SoundPathSpecifier pathSpecifier)
+            {
+                paths.Add(pathSpecifier.Path.CanonPath);
+            }
         }
         if (vocalizer.Comp.InteractFailureSound != null)
         {
-            var x = (SoundPathSpecifier)vocalizer.Comp.InteractFailureSound;
-            path1 = x.Path.ToString();
+            if (vocalizer.Comp.InteractFailureSound is SoundCollectionSpecifier cSpecifier &&
+                cSpecifier.Collection != null)
+            {
+                collections.Add(cSpecifier.Collection);
+            }
+            if (vocalizer.Comp.InteractFailureSound is SoundPathSpecifier pathSpecifier)
+            {
+                paths.Add(pathSpecifier.Path.CanonPath);
+            }
         }
-        foreach (var interact in _interactCVars)
+
+        if (collections.Count > 0)
         {
-            if (path1 != null && interact.Key.Contains(path1))
+            foreach (var interact in _interactCollectionCVars)
             {
-                play = interact.Value;
-                break;
-            }
-            if (path2 != null && interact.Key.Contains(path2))
-            {
-                play = interact.Value;
-                break;
+                if (interact.Key.Overlaps(collections))
+                    play = interact.Value;
             }
         }
+
+        if (paths.Count > 0)
+        {
+            foreach (var interact in _interactPathCVars)
+            {
+                if (interact.Key.Overlaps(paths))
+                    play = interact.Value;
+            }
+        }
+
         if (play == null)
-        {
             return true;
-        }
+
         return _config.GetClientCVar<bool>(forPlayer.Channel, play.Name);
     }
 }

--- a/Content.Shared/_Box/Audio/SpeciesMutingSystem.cs
+++ b/Content.Shared/_Box/Audio/SpeciesMutingSystem.cs
@@ -187,21 +187,23 @@ public sealed class SpeciesMutingSystem : EntitySystem
             {
                 collections.Add(specifier.Collection);
             }
-            if (vocalizer.Comp.InteractFailureSound is SoundPathSpecifier pathSpecifier)
+            else
             {
-                paths.Add(pathSpecifier.Path.CanonPath);
+                var x = (SoundPathSpecifier)vocalizer.Comp.InteractSuccessSound;
+                paths.Add(x.Path.CanonPath);
             }
         }
         if (vocalizer.Comp.InteractFailureSound != null)
         {
-            if (vocalizer.Comp.InteractFailureSound is SoundCollectionSpecifier cSpecifier &&
-                cSpecifier.Collection != null)
+            if (vocalizer.Comp.InteractFailureSound is SoundCollectionSpecifier specifier &&
+                specifier.Collection != null)
             {
-                collections.Add(cSpecifier.Collection);
+                collections.Add(specifier.Collection);
             }
-            if (vocalizer.Comp.InteractFailureSound is SoundPathSpecifier pathSpecifier)
+            else
             {
-                paths.Add(pathSpecifier.Path.CanonPath);
+                var x = (SoundPathSpecifier)vocalizer.Comp.InteractFailureSound;
+                paths.Add(x.Path.CanonPath);
             }
         }
 


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
followup to #215 
cleans up the code a bit, and handles the fact that interact sounds can be a SoundPathSpecifier or a SoundCollectionSpecifier
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
desk bells throw a casting error and fail to play their sound when you use them
## Technical details
<!-- Summary of code changes for easier review. -->
added logic for handling interact sounds that are specified as collections instead of paths
this is currently unused, but exists for future use and to prevent casting issues

also made the logic for determining if an interact sound should be muted decidedly less jank and hopefully slightly more efficient
previously it used two nullable strings and did a foreach to check the contents of each string against the dictionary
now it declares a hashset of strings, adds the mob's sound paths to the hashset if it exists, skips the foreach if the hashset is empty, and then checks if the mob's sound paths overlap with any of the dictionary entries
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Desk bells no longer throw an error and fail to make noise when used.
