### PR TITLE
[HOTFIX] Ruin Hotfixes

### DIFF
--- a/Resources/Maps/_Box/Ruins/strandedsyndicatecargo.yml
+++ b/Resources/Maps/_Box/Ruins/strandedsyndicatecargo.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 269.0.1
+  engineVersion: 272.0.1
   forkId: ""
   forkVersion: ""
-  time: 05/04/2026 10:54:24
-  entityCount: 431
+  time: 07/31/2026 23:05:09
+  entityCount: 433
 maps: []
 grids:
 - 1
@@ -356,7 +356,8 @@ entities:
           -3,0:
             0: 35338
           -3,1:
-            0: 52362
+            0: 51338
+            2: 1024
           -3,2:
             0: 34988
           -3,-1:
@@ -368,7 +369,7 @@ entities:
           -2,1:
             0: 56715
           -2,2:
-            2: 1
+            3: 1
             0: 56828
             1: 8192
           -2,3:
@@ -388,6 +389,11 @@ entities:
         - volume: 2500
           immutable: True
           moles: {}
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 21.6852
+            Nitrogen: 81.57766
         - volume: 2500
           temperature: 293.14975
           moles:
@@ -1117,6 +1123,16 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: ClothingHeadHelmetSyndicate
+  entities:
+  - uid: 432
+    components:
+    - type: Transform
+      parent: 335
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 335
 - proto: ClothingOuterCoatSyndieCap
   entities:
   - uid: 129
@@ -1126,6 +1142,16 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: ClothingOuterEVASuitSyndicate
+  entities:
+  - uid: 433
+    components:
+    - type: Transform
+      parent: 335
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 335
 - proto: ClothingOuterWinterSyndie
   entities:
   - uid: 130
@@ -2651,8 +2677,6 @@ entities:
       open: True
     - type: PlaceableSurface
       isPlaceable: True
-- proto: SuitStorageSyndie
-  entities:
   - uid: 335
     components:
     - type: Transform
@@ -2662,10 +2686,18 @@ entities:
       air:
         volume: 200
         immutable: False
-        temperature: 293.14673
+        temperature: 293.14697
         moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 432
+          - 433
 - proto: SurveillanceCameraMonitorCircuitboard
   entities:
   - uid: 336

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -77,10 +77,8 @@
           - /Maps/Ruins/hydro_outpost.yml
 #         - /Maps/Ruins/old_ai_sat.yml Box Change - replaced by old_syndicate_satellite
           - /Maps/Ruins/ruined_prison_ship.yml
-          - /Maps/Ruins/syndicate_dropship.yml
 #         - /Maps/Ruins/whiteship_ancient.yml # Box Change - Replaced by whiteship_ghost
 #         - /Maps/Ruins/syndicate_dropship.yml # Box Change - removes dropship ruin
-          - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
           - /Maps/Ruins/wrecklaimer.yml
           - /Maps/Ruins/displaced_telescience.yml


### PR DESCRIPTION
## About the PR
Maintain request.
-removes a mapped bloodred from a ruin (whoopsie).
-removes some code accidentally ported back in due to a merge conflict.

## Why / Balance
bugfix.

## Technical details
edited ruin: Resources/Maps/_Box/Ruins/strandedsyndicatecargo.yml
removes code from: Resources/Prototypes/Entities/Stations/base.yml

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- fix: Fixed an unintentional spawner on the ruined syndicate cargo ship.
- fix: Killed the syndicate dropship (For real this time).

