### PR TITLE
Readd "ScientistGear"

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -16,6 +16,14 @@
 
 - type: startingGear
   id: ScientistGear
+# Start Box Change - Null startingGear for Scientist
+#  equipment:
+    # ears: ClothingHeadsetScience
+  #storage:
+    #back:
+    #- Stuff
+# End Box Change
+
 
 - type: chameleonOutfit
   id: ScientistChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -7,22 +7,15 @@
     - !type:DepartmentTimeRequirement
       department: Science
       time: 5h # 2.5h -> 0 # Box Change - 0h > 5h
-  # startingGear: ScientistGear # Box Change: Prototype removed since it was null
+  startingGear: ScientistGear
   icon: "JobIconScientist"
   supervisors: job-supervisors-rd
   access:
   - Research
   - Maintenance
 
-# Start Box Change: Headset moved to loadout option. There's nothing left, so the entire thing needs to be commented out.
-#- type: startingGear
-#  id: ScientistGear
-#  equipment:
-    # ears: ClothingHeadsetScience
-  #storage:
-    #back:
-    #- Stuff
-# End Box Change
+- type: startingGear
+  id: ScientistGear
 
 - type: chameleonOutfit
   id: ScientistChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -16,14 +16,13 @@
 
 - type: startingGear
   id: ScientistGear
-# Start Box Change - Null startingGear for Scientist
+# Start Box Change - Null startingGear for Scientist - Wrist Comms
 #  equipment:
     # ears: ClothingHeadsetScience
   #storage:
     #back:
     #- Stuff
 # End Box Change
-
 
 - type: chameleonOutfit
   id: ScientistChameleonOutfit


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
Readds the "ScientistGear" startingGear removed in #181 

## Why / Balance
Despite being null, "ScientistGear" allows admins to force-pull someones science loadout if ever needed, such as in an admeme event, through the Debug>Set Outfit system

## Technical details
<!-- Summary of code changes for easier review. -->

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes


**Changelog**

