### PR TITLE
Minor Preset Overhaul - Adds Nukies, Redshift, & the Secret Preset

### DIFF
--- a/Resources/Locale/en-US/_Box/game-ticking/game-presets/preset-redshift.ftl
+++ b/Resources/Locale/en-US/_Box/game-ticking/game-presets/preset-redshift.ftl
@@ -1,0 +1,2 @@
+redshift-title = Redshift
+redshift-description = Extended, but without higher-tier ghostroles like LoneOps

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -197,7 +197,7 @@
     weight: 3.5 # Harmony 6.5 -> 3.5
     earliestStart: 40
     reoccurrenceDelay: 40 # Harmony 20 -> 40
-    minimumPlayers: 15 # Harmony 20 -> 15
+    minimumPlayers: 15 # Box 20 -> 15
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
@@ -229,7 +229,7 @@
     duration: null
     earliestStart: 30
     reoccurrenceDelay: 40 # Harmony 20 -> 40
-    minimumPlayers: 10 # Harmony 30 -> 10
+    minimumPlayers: 10 # Box 30 -> 10
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
   - type: AntagObjectives

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -197,7 +197,7 @@
     weight: 3.5 # Harmony 6.5 -> 3.5
     earliestStart: 40
     reoccurrenceDelay: 40 # Harmony 20 -> 40
-    minimumPlayers: 35 # Harmony 20 -> 35
+    minimumPlayers: 15 # Harmony 20 -> 15
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
@@ -229,7 +229,7 @@
     duration: null
     earliestStart: 30
     reoccurrenceDelay: 40 # Harmony 20 -> 40
-    minimumPlayers: 35 # Harmony 30 -> 35
+    minimumPlayers: 10 # Harmony 30 -> 10
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
   - type: AntagObjectives

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -47,7 +47,7 @@
     - id: NinjaSpawn
     - id: ParadoxCloneSpawn
     # - id: SleeperAgents # - Box Change, Comments out Sleeper Agent
-    - id: ZombieOutbreak
+    # - id: ZombieOutbreak # Box Change - Comments out Zeds
     - id: LoneOpsSpawn
     # - id: WizardSpawn - Harmony Change, disables wizard midround
     - id: BingleSpawn # Harmony
@@ -571,7 +571,7 @@
   - type: StationEvent
     earliestStart: 60 # Harmony 35 -> 60
     weight: 2 # Harmony 5.5 -> 2
-    minimumPlayers: 35 # Harmony 20 -> 35
+    minimumPlayers: 15 # Box 20 -> 15
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end screen (not always "Neutral outcome!") and... ending the game if the station is nuked.
   - type: RuleGrids
   - type: LoadMapRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -155,7 +155,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 20
+    # minPlayers: 20
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection
@@ -198,8 +198,9 @@
     - prefRoles: [ Nukeops ]
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
-      max: 2
-      playerRatio: 10
+      min: 0 # Box Change
+      # max: 2 # Box Change - Reset to default (1)
+      playerRatio: 20 # Box Change - 10 > 20
       startingGear: SyndicateOperativeGearFull
       roleLoadout:
       - RoleSurvivalNukie

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -139,7 +139,7 @@
     - NamesOperationSuffix
     nameFormat: name-format-nuclear-operation
   - type: NukeopsRule
-    warDeclarationMinOps: 3 # Harmony addition
+    warDeclarationMinOps: 1 # Harmony addition # Box Change - 3 > 1
   - type: RuleGrids
   - type: AntagSelection
   - type: AntagLoadProfileRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -155,7 +155,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    # minPlayers: 20
+    # minPlayers: 20 # Box Station - Enable Nukies
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection

--- a/Resources/Prototypes/_Box/GameRules/events.yml
+++ b/Resources/Prototypes/_Box/GameRules/events.yml
@@ -24,7 +24,7 @@
     - id: VentClog
 
 - type: entityTable
-  id: RedShiftAntagTable # Redshift Antags should be interesting but not round-ending or paradox clones
+  id: RedShiftAntagTable # Redshift Antags should be interesting but limited. Dangerous antags should be limited to "Survival" and "Extended"
   table: !type:AllSelector
     children:
     - !type:NestedSelector # DeltaV

--- a/Resources/Prototypes/_Box/GameRules/events.yml
+++ b/Resources/Prototypes/_Box/GameRules/events.yml
@@ -12,11 +12,11 @@
     - id: SolarFlare
 
 - type: entityTable
-  id: RedShiftEventsTable
+  id: RedShiftEventsTable # Redshift events should be interesting
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: BasicChillEventsTable
+      tableId: BasicChillEventsTable # No need to duplicate events
     - id: BreakerFlip
     - id: GasLeak
     - id: IonStorm
@@ -24,7 +24,7 @@
     - id: VentClog
 
 - type: entityTable
-  id: RedShiftAntagTable
+  id: RedShiftAntagTable # Redshift Antags should be interesting but not round-ending or paradox clones
   table: !type:AllSelector
     children:
     - !type:NestedSelector # DeltaV

--- a/Resources/Prototypes/_Box/GameRules/events.yml
+++ b/Resources/Prototypes/_Box/GameRules/events.yml
@@ -5,9 +5,38 @@
     - id: AnomalySpawn
     - id: BluespaceArtifact
     - id: BluespaceLocker
-    # - id: CockroachMigration
+    - id: CockroachMigration
     - id: MassHallucinations
-    # - id: MouseMigration
+    - id: MouseMigration
     - id: RandomSentience
     - id: SolarFlare
-    # - id: ClosetSkeleton
+
+- type: entityTable
+  id: RedShiftEventsTable
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: BasicChillEventsTable
+    - id: BreakerFlip
+    - id: GasLeak
+    - id: IonStorm
+    - id: PowerGridCheck
+    - id: VentClog
+
+- type: entityTable
+  id: RedShiftAntagTable
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector # DeltaV
+      tableId: BasicAntagEventsTableDeltaV
+    - !type:NestedSelector
+      tableId: DerelictBorgEventTable
+    - id: NinjaSpawn
+    - id: RevenantSpawn
+    - id: SlimesSpawn
+    - id: SnakeSpawn
+    - id: SpiderClownSpawn
+    - id: SpiderSpawn
+    - id: CarpMigration
+    - id: BingleSpawn
+    - id: SyndicateDeadDrop

--- a/Resources/Prototypes/_Box/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Box/GameRules/roundstart.yml
@@ -4,8 +4,8 @@
     children:
     - !type:NestedSelector
       tableId: BasicChillEventsTable
-    # - !type:NestedSelector
-    #   tableId: CalmPestEventsTable
+    - !type:NestedSelector
+      tableId: CalmPestEventsTable
     - !type:NestedSelector
       tableId: CargoGiftsTable
 
@@ -16,3 +16,31 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: ChillGameRulesTable
+
+- type: entityTable
+  id: RedShiftGameRulesTable
+  table: !type:AllSelector
+    children:
+    - !type:NestedSelector
+      tableId: RedShiftEventsTable
+    - !type:NestedSelector
+      tableId: RedShiftAntagTable
+    - !type:NestedSelector
+      tableId: CargoGiftsTable
+    - !type:NestedSelector
+      tableId: CalmPestEventsTable
+
+- type: entity
+  id: RedShiftEventsScheduler
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: RedShiftGameRulesTable
+
+- type: entity
+  parent: Nukeops
+  id: NukeopsRandom
+  components:
+  - type: GameRule
+    minPlayers: 15

--- a/Resources/Prototypes/_Box/game_presets.yml
+++ b/Resources/Prototypes/_Box/game_presets.yml
@@ -8,3 +8,28 @@
   - BasicRoundstartVariation
   - MeteorSwarmScheduler
   - ChillStationEventsScheduler
+
+- type: gamePreset
+  id: RedShift
+  name: chillshift-title
+  showInVote: false
+  description: chillshift-description
+  rules:
+  - SpaceTrafficControlFriendlyEventScheduler
+  - BasicRoundstartVariation
+  - MeteorSwarmScheduler
+  - RedShiftEventsScheduler
+
+- type: gamePreset
+  id: NukeopsRandom
+  alias:
+    - nukeopsrandom
+  name: nukeops-title
+  description: nukeops-description
+  showInVote: false
+  rules:
+  - Nukeops
+  - BasicStationEventScheduler
+  - MeteorSwarmScheduler
+  - SpaceTrafficControlEventScheduler
+  - BasicRoundstartVariation

--- a/Resources/Prototypes/_Box/game_presets.yml
+++ b/Resources/Prototypes/_Box/game_presets.yml
@@ -13,9 +13,7 @@
   - ChillStationEventsScheduler
 
 # Redshift
-  # Redshift is a custom alternate "Extended" that should in the long run put more of the interest in the unique and strange events rather than what player antags are rolled
-  # Redshift is not intended to be the place for admemes. That is either Chillshift or Extended.
-  # The goal of Redshift is to, eventually, reintroduce the random disaster of antag selection when antags are picked by Admins, and without being as destructive as Kessler
+  # Redshift is a custom alternate "Extended" that places the focus on the antags selected rather than destruction caused by events the game has picked.
 - type: gamePreset
   id: RedShift
   name: redshift-title

--- a/Resources/Prototypes/_Box/game_presets.yml
+++ b/Resources/Prototypes/_Box/game_presets.yml
@@ -1,3 +1,6 @@
+# Chillshift
+  # Chillshift is a custom alternate "Greenshift" that makes full room for roleplay while maintaining a degree of random events that prompt RP.
+  # Chillshift should never have antags.
 - type: gamePreset
   id: ChillShift
   name: chillshift-title
@@ -9,17 +12,23 @@
   - MeteorSwarmScheduler
   - ChillStationEventsScheduler
 
+# Redshift
+  # Redshift is a custom alternate "Extended" that should in the long run put more of the interest in the unique and strange events rather than what player antags are rolled
+  # Redshift is not intended to be the place for admemes. That is either Chillshift or Extended.
+  # The goal of Redshift is to, eventually, reintroduce the random disaster of antag selection when antags are picked by Admins, and without being as destructive as Kessler
 - type: gamePreset
   id: RedShift
-  name: chillshift-title
+  name: redshift-title
   showInVote: false
-  description: chillshift-description
+  description: redshift-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler
+  - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - MeteorSwarmScheduler
   - RedShiftEventsScheduler
 
+# Random Nukies
+  # Non-admin called Nukies with a min player count for Secret
 - type: gamePreset
   id: NukeopsRandom
   alias:

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,7 +1,7 @@
 - type: weightedRandom
   id: Secret
   weights:
-# Box Change Start - Completely rework
+# Box Change Start - Completely rework - New goal should be to use this when "Antags" are voted for
 # Harmony Changes
     # Traitor: 0.53
     # Conspiracy: 0.1
@@ -13,8 +13,8 @@
 # Harmony change. Remove Wizard and Kessler from the pool.
 #   Wizard: 0.04
 #   KesslerSyndrome: 0.01
-    Nukeops: 0.13
-    Survival: 0.13
-    ChillShift: 0.21
-    Extended: 0.53
+    NukeopsRandom: 0.13
+    Survival: 0.07
+    RedShift: 0.40
+    Extended: 0.40
 # Box Change End


### PR DESCRIPTION
## About the PR
- Tweaked the NukeOps presets so they can theoretically function on BoxStation pop
- Added Redshift, a new preset for admin-curated antag-driven gameplay.
- Tweaked the "Secret" preset so it can be used by Admins

As a part of the Nukies tweaks, LoneOps can spawn at 15+ pop
And, as part of Extended not being the sole preset, Ninjas and Dragons can now spawn naturally at Box pop levels

## Why / Balance
Nukies are an iconic part of Space Station 14 the admin team has from time to time toyed with using in admemes. However, by default the mechanics and prototypes fundementally do not work with BoxStation:
- BoxStation has a strong "latejoin" culture, preventing any serious "ready up" antags
- Even as a roundstart ghostrole, picking people to be Nukies would be logistically difficult
- The default amount of Nukies would overpower our pop levels

To address this, two new Nukie prototypes have been called: One Admins can call anytime, guaranteeing a Commander and Medic spawn (or ghost role versions thereof), and one that Secret can call but requiring 15 readied players.

Redshift exists as a preset that sits between Chillshift and Extended, allowing antags to thrive without having to worry about being usurped by a LoneOp or Dragon.

By tweaking the "Secret" preset, admins can call that instead of Extended, allowing for there be a random 13% chance of Nukies any antag-enabled BoxUp shift.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="1920" height="1032" alt="Screenshot 2026-08-07 204007" src="https://github.com/user-attachments/assets/077f4457-bc6e-4cdd-a592-d32a4b6c30cc" />
<img width="1920" height="1032" alt="Screenshot 2026-08-07 204050" src="https://github.com/user-attachments/assets/14b1e210-7f2f-4929-90d4-e16ce3c3937f" />


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes

**Changelog**
:cl:
- add: Added a new preset, Redshift, for admin-curated antagonist-driven gameplay!
- tweak: Changed NukeOps to be better balanced for BoxStation population
- tweak: LoneOps can now spawn when 15 or more players are in a round
- tweak: Ninjas can now spawn when 10 or more players are in a round
- tweak: Dragons can now spawn when 15 or more players are in a round
