### PR TITLE
Ports "Adds a Universal Saline for Nukies" from Harmony

### DIFF
--- a/Resources/Locale/en-US/_Harmony/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_Harmony/reagents/meta/medicine.ftl
@@ -1,0 +1,2 @@
+reagent-name-universal-blood = universal blood substitute
+reagent-desc-universal-blood = A blood substitute that works on all species and was invented by Interdyne Pharmaceutics. Concerns over the side effects of repeated exposure have prevented its wide spread adoption.

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -112,7 +112,10 @@
         - id: MedicatedSuture
         - id: RegenerativeMesh
         - id: SyringeEphedrine
-        - id: SyringeSaline
+        # Harmony Change Start - Nukie Universal Saline
+        # - id: SyringeSaline
+        - id: SyringeUniversalBlood # Nukie Medics spawn with a Combat Medkit, and CMOs are no longer mapped with them. A tasty treat for those rare few maps...
+        # Harmony Change End
         - id: BruteAutoInjector
         - id: BurnAutoInjector
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -58,6 +58,7 @@
     JugSulfur: 1
     JugWeldingFuel: 1
     PlasmaChemistryVial: 1
+    JugUniversalBlood: 1 # Harmony Change - Nukie Saline
   contrabandInventory:
     DrinkLithiumFlask: 1
     StrangePill: 3

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -473,7 +473,10 @@
       pen:
         maxVol: 40
         reagents:
-        - ReagentId: Saline
+        # Harmony Change - Nukie Universal Saline
+        # - ReagentId: Saline
+        - ReagentId: UniversalBlood
+        # Harmony Change End
           Quantity: 20
         - ReagentId: DexalinPlus
           Quantity: 20

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Chemistry/chemical-containers.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Chemistry/chemical-containers.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: Jug
+  id: JugUniversalBlood
+  categories: [ HideSpawnMenu ]
+  suffix: universal blood substitute, Harmony
+  components:
+  - type: Label
+    currentLabel: reagent-name-universal-blood
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: UniversalBlood
+          Quantity: 200

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Chemistry/chemical-containers.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Chemistry/chemical-containers.yml
@@ -8,7 +8,7 @@
     currentLabel: reagent-name-universal-blood
   - type: SolutionContainerManager
     solutions:
-      drink:
+      beaker: # Box Change - drink > beaker
         reagents:
         - ReagentId: UniversalBlood
           Quantity: 200

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Specific/Medical/healing.yml
@@ -1,0 +1,15 @@
+## Nukie Saline
+- type: entity
+  parent: PrefilledSyringe
+  id: SyringeUniversalBlood
+  suffix: universal blood substitute, Harmony
+  components:
+  - type: Label
+    currentLabel: reagent-name-universal-blood
+  - type: SolutionContainerManager
+    solutions:
+      injector:
+        maxVol: 15
+        reagents:
+          - ReagentId: UniversalBlood
+            Quantity: 15

--- a/Resources/Prototypes/_Harmony/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Harmony/Reagents/medicine.yml
@@ -1,0 +1,25 @@
+## Nukie Saline
+- type: reagent
+  id: UniversalBlood
+  name: reagent-name-universal-blood
+  group: Medicine
+  desc: reagent-desc-universal-blood
+  physicalDesc: reagent-physical-desc-ferrous
+  contrabandSeverity: Syndicate
+  flavor: metallic
+  color: "#9188BF"
+  metabolisms:
+  # Box Change Start - Pre-solutions refactor
+    # Bloodstream:
+    #   effects:
+    #     - !type:SatiateThirst
+    #       factor: 6
+    #     - !type:ModifyBloodLevel
+    #       amount: 6
+    Drink:
+      effects:
+        - !type:SatiateThirst
+          factor: 6
+        - !type:ModifyBloodLevel
+          amount: 6
+  # Box Change End

--- a/Resources/Prototypes/_Harmony/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Reactions/medicine.yml
@@ -12,3 +12,14 @@
       amount: 1
   products:
     Barozine: 2
+
+## Nukie Saline
+- type: reaction
+  id: UniversalBlood
+  reactants:
+    Vestine:
+      amount: 1
+    Saline:
+      amount: 3
+  products:
+    UniversalBlood: 4


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
Ports https://github.com/ss14-harmony/ss14-harmony/pull/1225

## Why / Balance
If we are considering running Nukies with Avali and IPCs, its necessary.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="789" height="548" alt="image" src="https://github.com/user-attachments/assets/04f6c6f0-3694-4cf3-a602-bfa38eb3879d" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added Universal Blood Substitue for Nuclear Operative Medics.
- tweak: The Combat Medkit now comes with a syringe of Universal Blood Substitute instead of a syringe of Saline
- tweak: Airloss Auto-Injectors now use Universal Blood Substitute instead of Saline
