### PR TITLE
[nubody] fix nukeops test fail

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -20,12 +20,14 @@ public sealed class InternalsSystem : SharedInternalsSystem
     [Dependency] private readonly RespiratorSystem _respirator = default!;
 
     private EntityQuery<InternalsComponent> _internalsQuery;
+    private EntityQuery<RespiratorComponent> _respiratorQuery; // Box Change: Stop TryStopNukeOpsFromConstantlyFailing from occasionally failing due to IPCs not having RespiratorComponent
 
     public override void Initialize()
     {
         base.Initialize();
 
         _internalsQuery = GetEntityQuery<InternalsComponent>();
+        _respiratorQuery = GetEntityQuery<RespiratorComponent>();// Box Change: Stop TryStopNukeOpsFromConstantlyFailing from occasionally failing due to IPCs not having RespiratorComponent
 
         SubscribeLocalEvent<InternalsComponent, InhaleLocationEvent>(OnInhaleLocation);
         SubscribeLocalEvent<InternalsComponent, StartingGearEquippedEvent>(OnStartingGear);
@@ -38,6 +40,11 @@ public sealed class InternalsSystem : SharedInternalsSystem
 
         if (component.GasTankEntity != null)
             return; // already connected
+
+        // Start Box Change: Stop TryStopNukeOpsFromConstantlyFailing from occasionally failing due to IPCs not having RespiratorComponent
+        if (!_respiratorQuery.HasComp(uid))
+            return;
+        // End Box Change
 
         // Can the entity breathe the air it is currently exposed to?
         if (_respirator.CanMetabolizeInhaledAir(uid))


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
when nukies spawn, `InternalsSystem.OnStartingGear()` tries to set them up with appropriate internals and turn them on if necessary (so vox don't spawn in poison air)
however at some point in the process a check isn't set to not error if the target doesn't have a respirator component
ipcs don't have respirator components so an ipc nukie spawning in the test would cause a test fail
this fix simply aborts `InternalsSystem.OnStartingGear()` early if the entity does not have a respirator component (since it doesn't need internals anyways)
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
