### PR TITLE
tweak: move glasses back below hair

### DIFF
--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -37,7 +37,7 @@
     - map: [ "gloves" ]
     - map: [ "shoes" ]
     # - map: [ "ears" ] # Harmony Change: Moves ears over facialhair and headside
-    # - map: [ "eyes" ] # Harmony Change: Moves eyes over facialhair and headside
+    # - map: [ "eyes" ] # Box Change: Moves eyes over facialhair
     # - map: [ "belt" ] # Harmony Change: Moves Belt back over outerclothing
     - map: [ "id" ]
     - map: [ "outerClothing" ]
@@ -49,6 +49,7 @@
     # Stuff that goes in front of equipment
     - map: [ "enum.HumanoidVisualLayers.SnoutCover" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
+    - map: [ "eyes" ] # Box Change: Moves eyes over facialhair but behind hair
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
     - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
     - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
@@ -57,7 +58,6 @@
 
     # Stuff that goes in front of stuff that goes in front of equipment
     - map: [ "ears" ] # Harmony Change: Moves ears over facialhair and headside
-    - map: [ "eyes" ] # Harmony Change: Moves eyes over facialhair and headside
     - map: [ "mask" ]
     - map: [ "head" ]
     - map: [ "pocket1" ]


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
moves glasses layer below the hair layer
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
because it looks really really weird and awkward
this does reintroduce minor glasses clipping with avali and thaven (usually, it's literally a single pixel on each side) but these are (imo) far less offputting than having bigass glasses that render over the hair that's supposed to cover your face
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="526" height="1107" alt="image" src="https://github.com/user-attachments/assets/1f6a7b2d-8412-413e-8a4a-bd795b881544" />

<img width="1161" height="342" alt="image" src="https://github.com/user-attachments/assets/13a2432d-c23a-4a2b-82b4-b00959261c4d" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
