### PR TITLE
Allow admins to create an automated antag vote

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-secret.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-secret.ftl
@@ -1,4 +1,6 @@
-secret-title = Secret
+# Box Change Start - Secret > Antags - Antag Votes
+secret-title = Antags
+# Box Change End
 secret-description = It's a secret to everyone. The threats you encounter are randomized.
 
 dynamic-title = Dynamic

--- a/Resources/Prototypes/_Box/game_presets.yml
+++ b/Resources/Prototypes/_Box/game_presets.yml
@@ -4,7 +4,7 @@
 - type: gamePreset
   id: ChillShift
   name: chillshift-title
-  showInVote: false
+  showInVote: true
   description: chillshift-description
   rules:
   - SpaceTrafficControlFriendlyEventScheduler

--- a/Resources/Prototypes/_Harmony/game_presets.yml
+++ b/Resources/Prototypes/_Harmony/game_presets.yml
@@ -1,17 +1,19 @@
-- type: gamePreset
-  id: SecretNukeops #For Admin Use: Runs Nukeops but shows "Secret" in lobby.
-  alias:
-    - secretnukeops
-  name: secret-title
-  description: secret-description
-  showInVote: false #Admin Use
-  rules:
-    - Nukeops
-    - SubGamemodesRule
-    - BasicStationEventScheduler
-    - MeteorSwarmScheduler
-    - SpaceTrafficControlEventScheduler
-    - BasicRoundstartVariation
+# Box Change Start - If we force Nukies, it'll be an admeme and should be announced
+# - type: gamePreset
+#   id: SecretNukeops #For Admin Use: Runs Nukeops but shows "Secret" in lobby.
+#   alias:
+#     - secretnukeops
+#   name: secret-title
+#   description: secret-description
+#   showInVote: false #Admin Use
+#   rules:
+#     - Nukeops
+#     - SubGamemodesRule
+#     - BasicStationEventScheduler
+#     - MeteorSwarmScheduler
+#     - SpaceTrafficControlEventScheduler
+#     - BasicRoundstartVariation
+# Box Change End
 
 - type: gamePreset
   id: DeathmatchPROMOD
@@ -21,7 +23,7 @@
   name: death-match-promod-title
   description: death-match-promod-description
   maxPlayers: 15
-  showInVote: true
+  showInVote: false # Box Change - true > false - Antag Votes
   supportedMaps: DeathMatchPROMODMapPool
   rules:
     - DeathMatchPROMOD

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -121,9 +121,13 @@
   alias:
     - secret
     - sekrit
+  # Box Change Start - Antag Votes
+    - Antags
+    - antags
+  # Box Change End
   name: secret-title
   showInVote: true
-  description: secret-description
+  description: dynamic-description # Box Change - secret- > dynamic- - Antag Votes
   rules:
     - Secret
 
@@ -166,7 +170,7 @@
   name: death-match-title
   description: death-match-description
   maxPlayers: 15
-  showInVote: true
+  showInVote: false # Box Change - true > false - Antag Votes
   supportedMaps: DeathMatchMapPool
   rules:
     - DeathMatch31


### PR DESCRIPTION
## About the PR
Clean up the `showInVote` for presets and rename Secret to Antags

## Why / Balance
Allows Admins to call an automatic antag vote using `createvote Preset`

## Technical details


## Media
<img width="319" height="137" alt="Screenshot 2026-08-11 155300" src="https://github.com/user-attachments/assets/a645e975-6ef1-4d68-9677-5e61930c5549" />

<img width="425" height="108" alt="Screenshot 2026-08-11 160243" src="https://github.com/user-attachments/assets/caa06d07-99e5-4be3-babb-adda0c52f405" />

<img width="1837" height="791" alt="Screenshot 2026-08-11 160332" src="https://github.com/user-attachments/assets/d33363d5-a301-43d8-9db6-d7d72ceddad4" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes

**Changelog**
