### PR TITLE
fix narcolepsy speech randomly getting deleted

### DIFF
--- a/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
+++ b/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Bed.Sleep;
-using Content.Shared.Chat; // Box Change: Narcolepsy speech fix
 using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.ForceSay;
@@ -7,6 +6,7 @@ using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Speech; // Box Change: Narcolepsy speech fix
 using Content.Shared.Stunnable;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -34,7 +34,7 @@ public sealed class DamageForceSaySystem : EntitySystem
         // (this won't double raise, because of the cooldown)
         SubscribeLocalEvent<DamageForceSayComponent, DamageChangedEvent>(OnDamageChanged, after: new []{ typeof(MobThresholdSystem)} );
         SubscribeLocalEvent<DamageForceSayComponent, SleepStateChangedEvent>(OnSleep);
-        SubscribeLocalEvent<AllowNextCritSpeechComponent, CheckIgnoreSpeechBlockerEvent>(OnCheckIgnoreSpeechBlocker); // Box Change: Narcolepsy speech fix
+        SubscribeLocalEvent<AllowNextCritSpeechComponent, SpeakAttemptEvent>(OnSpeakAttempt); // Box Change: Narcolepsy speech fix
     }
 
     public override void Update(float frameTime)
@@ -132,12 +132,11 @@ public sealed class DamageForceSaySystem : EntitySystem
         TryForceSay(uid, component, false);
         AllowNextSpeech(uid);
     }
-    // Start Box Change: Narcolepsy speech fix - Use CheckIgnoreSpeechBlockerEvent for more consistency
-    private void OnCheckIgnoreSpeechBlocker(EntityUid uid, AllowNextCritSpeechComponent component, CheckIgnoreSpeechBlockerEvent args)
+    // Start Box Change: Narcolepsy speech fix
+    private void OnSpeakAttempt(EntityUid uid, AllowNextCritSpeechComponent component, SpeakAttemptEvent args)
     {
         if (HasComp<AllowNextCritSpeechComponent>(uid))
         {
-            args.IgnoreBlocker = true;
             RemCompDeferred<AllowNextCritSpeechComponent>(uid);
         }
     }

--- a/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
+++ b/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Chat; // Box Change: Narcolepsy speech fix
 using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.ForceSay;
@@ -33,6 +34,7 @@ public sealed class DamageForceSaySystem : EntitySystem
         // (this won't double raise, because of the cooldown)
         SubscribeLocalEvent<DamageForceSayComponent, DamageChangedEvent>(OnDamageChanged, after: new []{ typeof(MobThresholdSystem)} );
         SubscribeLocalEvent<DamageForceSayComponent, SleepStateChangedEvent>(OnSleep);
+        SubscribeLocalEvent<AllowNextCritSpeechComponent, CheckIgnoreSpeechBlockerEvent>(OnCheckIgnoreSpeechBlocker); // Box Change: Narcolepsy speech fix
     }
 
     public override void Update(float frameTime)
@@ -130,4 +132,14 @@ public sealed class DamageForceSaySystem : EntitySystem
         TryForceSay(uid, component, false);
         AllowNextSpeech(uid);
     }
+    // Start Box Change: Narcolepsy speech fix - Use CheckIgnoreSpeechBlockerEvent for more consistency
+    private void OnCheckIgnoreSpeechBlocker(EntityUid uid, AllowNextCritSpeechComponent component, CheckIgnoreSpeechBlockerEvent args)
+    {
+        if (HasComp<AllowNextCritSpeechComponent>(uid))
+        {
+            args.IgnoreBlocker = true;
+            RemCompDeferred<AllowNextCritSpeechComponent>(uid);
+        }
+    }
+    // End Box Change
 }

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -166,7 +166,7 @@ public sealed partial class SleepingSystem : EntitySystem
         // TODO reduce duplication of this behavior with MobStateSystem somehow
         if (HasComp<AllowNextCritSpeechComponent>(ent))
         {
-            RemCompDeferred<AllowNextCritSpeechComponent>(ent);
+            //RemCompDeferred<AllowNextCritSpeechComponent>(ent); // Box Change: Narcolepsy speech fix - Comp is removed elsewhere to avoid duplicated requests
             return;
         }
 

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Bed.Sleep;
+using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage;
@@ -161,7 +161,7 @@ public partial class MobStateSystem
     {
         if (HasComp<AllowNextCritSpeechComponent>(uid))
         {
-            RemCompDeferred<AllowNextCritSpeechComponent>(uid);
+            //RemCompDeferred<AllowNextCritSpeechComponent>(uid); // Box Change: Narcolepsy speech fix - Comp is removed elsewhere to avoid duplicated requests
             return;
         }
 


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
when a narcoleptic character falls asleep while typing it's supposed to send the message early and add a -zzz at the end but as it stands most of the time it doesn't do that and instead just eats your message whole
this fixes that

i submitted this to upstream but we have some people here who would probably appreciate getting it sooner than later
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it's bad
## Technical details
<!-- Summary of code changes for easier review. -->
SleepingSystem and MobStateSystem both check and queue removal of AllowNextCritSpeechComponent and both get called when going to sleep which is probably not good so i consolidated them into a single function as part of DamageForceSaySystem (the only system which uses AllowNextCritSpeechComponent). this seems to fix the issue (which was probably caused by the component getting overzealously deleted)

if you want to test it yourself modify the narcolepsy trait in `Resources/Prototypes/Traits/disabilities.yml` like this to make it easier

```yaml
- type: trait
  id: Narcolepsy
  name: trait-narcolepsy-name
  description: trait-narcolepsy-desc
  category: Disabilities
  components:
    - type: Narcolepsy
      maxTimeBetweenIncidents: 6
      minTimeBetweenIncidents: 3
      maxDurationOfIncident: 3
      minDurationOfIncident: 1
```

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/e6322a8b-8766-4fbd-9ec1-ce643e4d3600

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Narcoleptic characters will no longer find their messages being lost to the Great Abyss when falling asleep mid-sentence.
