### PR TITLE
[nubody hotfix] restore ipc bloodloss behaviors + damage visuals + deathgasp

### DIFF
--- a/Resources/Prototypes/_Box/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_Box/Body/Species/ipc.yml
@@ -156,6 +156,19 @@
   - type: Damageable
     damageContainer: HumanoidSilicon
     damageModifierSet: IPC
+  - type: DamageVisuals
+    thresholds: [ 10, 20, 30, 50, 70, 100 ]
+    targetLayers:
+      - "enum.HumanoidVisualLayers.Chest"
+      - "enum.HumanoidVisualLayers.Head"
+      - "enum.HumanoidVisualLayers.LArm"
+      - "enum.HumanoidVisualLayers.LLeg"
+      - "enum.HumanoidVisualLayers.RArm"
+      - "enum.HumanoidVisualLayers.RLeg"
+    damageOverlayGroups:
+      Brute:
+        sprite: Mobs/Effects/brute_damage.rsi
+        color: "#DD8822"
   # - type: Deathgasp # Commented out in original, probably for a good reason?
   #   prototype: SiliconDeathgasp
   #   needsCritical: false
@@ -224,6 +237,17 @@
       reagents:
         - ReagentId: IPCOil # IPC blood effectively
           Quantity: 300
+    bleedReductionAmount: 0.25 # Less than an organic (no clotting), but still there
+    bleedPuddleThreshold: 3
+    bloodRefreshAmount: 0
+    bloodlossThreshold: 0.7 # IPCs bleed for longer and cannot restore blood naturally. Bleeding should punish them less.
+    bloodlossDamage:
+      types:
+        Blunt: 0.25
+        Heat: 0.25
+    bloodlossHealDamage:
+      types:
+        Burn: 0
   - type: TypingIndicator
     proto: ipc
   - type: Destructible

--- a/Resources/Prototypes/_Box/Body/Species/ipc.yml
+++ b/Resources/Prototypes/_Box/Body/Species/ipc.yml
@@ -169,9 +169,8 @@
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
         color: "#DD8822"
-  # - type: Deathgasp # Commented out in original, probably for a good reason?
-  #   prototype: SiliconDeathgasp
-  #   needsCritical: false
+  - type: Deathgasp
+    prototype: SiliconDeathgasp
   - type: MobState
     allowedStates:
       - Alive


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
fixes ipcs not taking bloodloss, regenerating blood, and having generic human damage visuals
also not doing their deathgasp
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
broke
## Technical details
<!-- Summary of code changes for easier review. -->
copied over some yaml from pre-nubody EE silicon base and removed most of the commented stuff because it's no longer necessary
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
before
<img width="596" height="363" alt="Content Client_DXiDzAX3Wu" src="https://github.com/user-attachments/assets/3d9d05ca-110a-4120-8656-5c4e922b1458" />

after
<img width="792" height="613" alt="Content Client_VGgb4RGWFP" src="https://github.com/user-attachments/assets/8eaa769a-7745-47dc-817b-00fc62a2b222" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

