### PR TITLE
Buff the Syndicate Indoor Modkit

### DIFF
--- a/Content.Shared/_DV/Weapons/Ranged/Ugrades/GunUpgradeIndoorsComponent.cs
+++ b/Content.Shared/_DV/Weapons/Ranged/Ugrades/GunUpgradeIndoorsComponent.cs
@@ -12,5 +12,5 @@ public sealed partial class GunUpgradeIndoorsComponent : Component
     /// Pressure modifier is multiplied by this by each upgrade.
     /// </summary>
     [DataField]
-    public float Multiplier = 2f;
+    public float Multiplier = 4f; // Box Change - 2f > 4f - One modkit should be enough.
 }

--- a/Content.Shared/_DV/Weapons/Ranged/Ugrades/GunUpgradeIndoorsSystem.cs
+++ b/Content.Shared/_DV/Weapons/Ranged/Ugrades/GunUpgradeIndoorsSystem.cs
@@ -34,7 +34,6 @@ public sealed class GunUpgradeIndoorsSystem : EntitySystem
             _popup.PopupClient(Loc.GetString("upgradeable-gun-popup-too-many"), args.Gun, args.User);
             args.Cancelled = true;
             return;
-
         }
     }
 

--- a/Content.Shared/_DV/Weapons/Ranged/Ugrades/GunUpgradeIndoorsSystem.cs
+++ b/Content.Shared/_DV/Weapons/Ranged/Ugrades/GunUpgradeIndoorsSystem.cs
@@ -28,12 +28,13 @@ public sealed class GunUpgradeIndoorsSystem : EntitySystem
         foreach (var upgrade in _upgrade.GetCurrentUpgrades(args.Gun))
         {
             // only allow 2 of them to be installed max to prevent doing double damage
-            if (!HasComp<GunUpgradeIndoorsComponent>(ent) || ++count < 2)
+            if (!HasComp<GunUpgradeIndoorsComponent>(ent)) // || ++count < 2) // Box Change start - Only 1 is needed
                 continue;
 
             _popup.PopupClient(Loc.GetString("upgradeable-gun-popup-too-many"), args.Gun, args.User);
             args.Cancelled = true;
             return;
+
         }
     }
 

--- a/Resources/Prototypes/_DV/Catalog/Uplink/job.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/job.yml
@@ -18,3 +18,4 @@
   - !type:BuyerJobCondition
     whitelist:
     - SalvageSpecialist
+    - Scientist # Box Change - Allow Sci to get it as well

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/pka_ugrade.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/pka_ugrade.yml
@@ -18,7 +18,7 @@
   - type: GunUpgrade
     examineText: gun-upgrade-examine-text-indoors
   - type: GunUpgradeCost
-    cost: 35
+    cost: 10 # Box Change - 35 > 10 - More viable modkit
   - type: GunUpgradeIndoors
 # Start harmony change
 #  - type: MappingCategories # its evil


### PR DESCRIPTION
## About the PR
Make the indoor modkit take up less space in a PKA, be twice as effective, and gives it to Scientists as well.
Only one indoor modkit can be inserted into a PKA

## Why / Balance
Indoor Modkits were designed on DeltaV, PKAs did 40 damage by default. You needed two for a PKA to do full damage, and you only get 1 per uplink purchase.

I don't think a single person has ever bought and used it.

The modkit capacity useage has been lowered from 35 to 10, allowing it to be used in a fully upgraded PKA.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- add: Syndicate Scientists can now purchased Indoor Modkits
- tweak: Indoor Modkits now take up less space in PKAs and are twice as effective
- tweak: You can now only have one indoor modkit in a PKA

