### PR TITLE
Modkit Overhaul

### DIFF
--- a/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
@@ -19,5 +19,6 @@ public record struct GunRefreshModifiersEvent(
     Angle MinAngle,
     int ShotsPerBurst,
     float FireRate,
-    float ProjectileSpeed
+    float ProjectileSpeed,
+    float RateMult = 1f // Box Change - Modkit Overhaul
 );

--- a/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
@@ -20,5 +20,5 @@ public record struct GunRefreshModifiersEvent(
     int ShotsPerBurst,
     float FireRate,
     float ProjectileSpeed,
-    float RateMult = 1f // Box Change - Modkit Overhaul
+    float ModkitRateMult = 1f // Box Change - Modkit Overhaul - Stores the Modkit firerate multiplier
 );

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -693,7 +693,7 @@ public record struct AttemptShootEvent(EntityUid User, string? Message, bool Can
 /// </summary>
 /// <param name="User">The user that fired this gun.</param>
 [ByRefEvent]
-public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo, float DamageMult = 1f); // Box Change - Add float DamageMult
+public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo, float ModkitDamageMult = 1f); // Box Change - Add float ModkitDamageMult; stores the Modkit damage multiplier
 
 /// <summary>
 /// Raised on an entity after firing a gun to see if any components or systems would allow this entity to be pushed

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -693,7 +693,7 @@ public record struct AttemptShootEvent(EntityUid User, string? Message, bool Can
 /// </summary>
 /// <param name="User">The user that fired this gun.</param>
 [ByRefEvent]
-public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo);
+public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo, float DamageMult = 1f); // Box Change - Add float DamageMult
 
 /// <summary>
 /// Raised on an entity after firing a gun to see if any components or systems would allow this entity to be pushed

--- a/Content.Shared/Weapons/Ranged/Upgrades/Components/GunUpgradeDamageComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/Components/GunUpgradeDamageComponent.cs
@@ -9,9 +9,17 @@ namespace Content.Shared.Weapons.Ranged.Upgrades.Components;
 [RegisterComponent, NetworkedComponent, Access(typeof(GunUpgradeSystem))]
 public sealed partial class GunUpgradeDamageComponent : Component
 {
+// Box Change Start - Move to coefficient
+    // /// <summary>
+    // /// Additional damage added onto the projectile's base damage.
+    // /// </summary>
+    // [DataField]
+    // public DamageSpecifier Damage = new();
+
     /// <summary>
-    /// Additional damage added onto the projectile's base damage.
+    /// Additional damage added onto the projectile.
+    /// Each modkit adds to the total coefficient.
     /// </summary>
     [DataField]
-    public DamageSpecifier Damage = new();
+    public float DamageCoefficient = 0.5f; // Could this be replaced with a coefficient per damage type?
 }

--- a/Content.Shared/Weapons/Ranged/Upgrades/Components/GunUpgradeDamageComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/Components/GunUpgradeDamageComponent.cs
@@ -22,4 +22,5 @@ public sealed partial class GunUpgradeDamageComponent : Component
     /// </summary>
     [DataField]
     public float DamageCoefficient = 0.5f; // Could this be replaced with a coefficient per damage type?
+// Box Change End
 }

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Shared._DV.Weapons.Ranged.Upgrades; // DeltaV
+using Content.Shared._Box.Weapons.Ranged.Upgrades; // Box Change - Modkit Coefficient Rework
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;
@@ -33,14 +34,16 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
         SubscribeLocalEvent<UpgradeableGunComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
         SubscribeLocalEvent<UpgradeableGunComponent, ExaminedEvent>(OnExamine);
 
-        SubscribeLocalEvent<UpgradeableGunComponent, GunRefreshModifiersEvent>(RelayEvent);
-        SubscribeLocalEvent<UpgradeableGunComponent, GunShotEvent>(RelayEvent);
+        SubscribeLocalEvent<UpgradeableGunComponent, GunRefreshModifiersEvent>(RelayRefresh); // Box Change - RelayEvent > RelayRefresh - Modkit Coefficient Rework
+        SubscribeLocalEvent<UpgradeableGunComponent, GunShotEvent>(RelayShot); // Box Change - RelayEvent > RelayShot - Modkit Coefficient Rework
 
         SubscribeLocalEvent<GunUpgradeFireRateComponent, GunRefreshModifiersEvent>(OnFireRateRefresh);
         SubscribeLocalEvent<GunUpgradeSpeedComponent, GunRefreshModifiersEvent>(OnSpeedRefresh);
         SubscribeLocalEvent<GunUpgradeDamageComponent, GunShotEvent>(OnDamageGunShot);
     }
 
+    // Box Change Start - Modkit Coefficient Overhaul
+    /*
     private void RelayEvent<T>(Entity<UpgradeableGunComponent> ent, ref T args) where T : notnull
     {
         foreach (var upgrade in GetCurrentUpgrades(ent))
@@ -48,6 +51,26 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
             RaiseLocalEvent(upgrade, ref args);
         }
     }
+    */
+    private void RelayShot(Entity<UpgradeableGunComponent> ent, ref GunShotEvent args)
+    {
+        foreach (var upgrade in GetCurrentUpgrades(ent))
+        {
+            RaiseLocalEvent(upgrade, ref args);
+        }
+    }
+
+    private void RelayRefresh(Entity<UpgradeableGunComponent> ent, ref GunRefreshModifiersEvent args)
+    {
+        var fireRate = args.FireRate;
+        args.FireRate = 1;
+        foreach (var upgrade in GetCurrentUpgrades(ent))
+        {
+            RaiseLocalEvent(upgrade, ref args);
+        }
+        args.FireRate *= fireRate;
+    }
+    // Box Change End
 
     private void OnExamine(Entity<UpgradeableGunComponent> ent, ref ExaminedEvent args)
     {
@@ -106,7 +129,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
 
     private void OnFireRateRefresh(Entity<GunUpgradeFireRateComponent> ent, ref GunRefreshModifiersEvent args)
     {
-        args.FireRate *= ent.Comp.Coefficient;
+        args.FireRate += ent.Comp.Coefficient; // Box Change - * > + - Modkit Coefficient Overhaul
     }
 
     private void OnSpeedRefresh(Entity<GunUpgradeSpeedComponent> ent, ref GunRefreshModifiersEvent args)

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Shared._DV.Weapons.Ranged.Upgrades; // DeltaV
-using Content.Shared._Box.Weapons.Ranged.Upgrades; // Box Change - Modkit Coefficient Rework
 using Robust.Shared.Spawners; // Box Change - Modkit Coefficient Rework
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -63,7 +62,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
         foreach (var (ammo, _) in args.Ammo)
         {
             if (TryComp<ProjectileComponent>(ammo, out var proj))
-                proj.Damage *= args.DamageMult;
+                proj.Damage *= args.ModkitDamageMult;
         }
     }
 
@@ -73,7 +72,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
         {
             RaiseLocalEvent(upgrade, ref args);
         }
-        args.FireRate *= args.RateMult;
+        args.FireRate *= args.ModkitRateMult;
     }
     // Box Change End
 
@@ -134,7 +133,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
 
     private void OnFireRateRefresh(Entity<GunUpgradeFireRateComponent> ent, ref GunRefreshModifiersEvent args)
     {
-        args.RateMult += ent.Comp.Coefficient; // Box Change - args.FireRate > args.RateMult - * > + - Modkit Coefficient Overhaul
+        args.ModkitRateMult += ent.Comp.Coefficient; // Box Change - args.FireRate > args.RateMult - * > + - Modkit Coefficient Overhaul
     }
 
     // Box Change Start - Modkit Coefficient Rework
@@ -157,7 +156,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
     private void OnDamageGunShot(Entity<GunUpgradeDamageComponent> ent, ref GunShotEvent args)
     {
     // Box Change Start - Modkit Overhaul
-        args.DamageMult = args.DamageMult += ent.Comp.DamageCoefficient;
+        args.ModkitDamageMult += ent.Comp.DamageCoefficient;
         // foreach (var (ammo, _) in args.Ammo)
         // {
         //     if (TryComp<ProjectileComponent>(ammo, out var proj))

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -60,13 +60,11 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
             RaiseLocalEvent(upgrade, ref args);
         }
 
-    // Box Change Start - Modkit Overhaul
         foreach (var (ammo, _) in args.Ammo)
         {
             if (TryComp<ProjectileComponent>(ammo, out var proj))
                 proj.Damage *= args.DamageMult;
         }
-    // Box Change End
     }
 
     private void RelayRefresh(Entity<UpgradeableGunComponent> ent, ref GunRefreshModifiersEvent args)

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared._DV.Weapons.Ranged.Upgrades; // DeltaV
 using Content.Shared._Box.Weapons.Ranged.Upgrades; // Box Change - Modkit Coefficient Rework
+using Robust.Shared.Spawners;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;
@@ -38,7 +39,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
         SubscribeLocalEvent<UpgradeableGunComponent, GunShotEvent>(RelayShot); // Box Change - RelayEvent > RelayShot - Modkit Coefficient Rework
 
         SubscribeLocalEvent<GunUpgradeFireRateComponent, GunRefreshModifiersEvent>(OnFireRateRefresh);
-        SubscribeLocalEvent<GunUpgradeSpeedComponent, GunRefreshModifiersEvent>(OnSpeedRefresh);
+        SubscribeLocalEvent<GunUpgradeSpeedComponent, GunShotEvent>(OnSpeedRefresh); // Box Change - GunRefreshModifiersEvent > GunShotEvent - Modkit Coefficient Rework
         SubscribeLocalEvent<GunUpgradeDamageComponent, GunShotEvent>(OnDamageGunShot);
     }
 
@@ -132,10 +133,22 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
         args.FireRate += ent.Comp.Coefficient; // Box Change - * > + - Modkit Coefficient Overhaul
     }
 
+    // Box Change Start - Modkit Coefficient Rework
+    /*
     private void OnSpeedRefresh(Entity<GunUpgradeSpeedComponent> ent, ref GunRefreshModifiersEvent args)
     {
         args.ProjectileSpeed *= ent.Comp.Coefficient;
     }
+    */
+    private void OnSpeedRefresh(Entity<GunUpgradeSpeedComponent> ent, ref GunShotEvent args)
+    {
+        foreach (var (ammo, _) in args.Ammo)
+        {
+            if (TryComp<TimedDespawnComponent>(ammo, out var proj))
+                proj.Lifetime += ent.Comp.Coefficient;
+        }
+    }
+    // Box Change End
 
     private void OnDamageGunShot(Entity<GunUpgradeDamageComponent> ent, ref GunShotEvent args)
     {

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -71,13 +71,11 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
 
     private void RelayRefresh(Entity<UpgradeableGunComponent> ent, ref GunRefreshModifiersEvent args)
     {
-        var fireRate = args.FireRate;
-        args.FireRate = 1;
         foreach (var upgrade in GetCurrentUpgrades(ent))
         {
             RaiseLocalEvent(upgrade, ref args);
         }
-        args.FireRate *= fireRate;
+        args.FireRate *= args.RateMult;
     }
     // Box Change End
 
@@ -138,7 +136,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
 
     private void OnFireRateRefresh(Entity<GunUpgradeFireRateComponent> ent, ref GunRefreshModifiersEvent args)
     {
-        args.FireRate += ent.Comp.Coefficient; // Box Change - * > + - Modkit Coefficient Overhaul
+        args.RateMult += ent.Comp.Coefficient; // Box Change - args.FireRate > args.RateMult - * > + - Modkit Coefficient Overhaul
     }
 
     // Box Change Start - Modkit Coefficient Rework

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using Content.Shared._DV.Weapons.Ranged.Upgrades; // DeltaV
 using Content.Shared._Box.Weapons.Ranged.Upgrades; // Box Change - Modkit Coefficient Rework
-using Robust.Shared.Spawners;
+using Robust.Shared.Spawners; // Box Change - Modkit Coefficient Rework
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -133,7 +133,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
 
     private void OnFireRateRefresh(Entity<GunUpgradeFireRateComponent> ent, ref GunRefreshModifiersEvent args)
     {
-        args.ModkitRateMult += ent.Comp.Coefficient; // Box Change - args.FireRate > args.RateMult - * > + - Modkit Coefficient Overhaul
+        args.ModkitRateMult += ent.Comp.Coefficient; // Box Change - args.FireRate > args.ModkitRateMult - * > + - Modkit Coefficient Overhaul
     }
 
     // Box Change Start - Modkit Coefficient Rework

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -59,6 +59,14 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
         {
             RaiseLocalEvent(upgrade, ref args);
         }
+
+    // Box Change Start - Modkit Overhaul
+        foreach (var (ammo, _) in args.Ammo)
+        {
+            if (TryComp<ProjectileComponent>(ammo, out var proj))
+                proj.Damage *= args.DamageMult;
+        }
+    // Box Change End
     }
 
     private void RelayRefresh(Entity<UpgradeableGunComponent> ent, ref GunRefreshModifiersEvent args)
@@ -152,11 +160,14 @@ public sealed partial class GunUpgradeSystem : EntitySystem // DeltaV - made par
 
     private void OnDamageGunShot(Entity<GunUpgradeDamageComponent> ent, ref GunShotEvent args)
     {
-        foreach (var (ammo, _) in args.Ammo)
-        {
-            if (TryComp<ProjectileComponent>(ammo, out var proj))
-                proj.Damage += ent.Comp.Damage;
-        }
+    // Box Change Start - Modkit Overhaul
+        args.DamageMult = args.DamageMult += ent.Comp.DamageCoefficient;
+        // foreach (var (ammo, _) in args.Ammo)
+        // {
+        //     if (TryComp<ProjectileComponent>(ammo, out var proj))
+        //         proj.Damage += ent.Comp.Damage;
+        // }
+    // Box Change End
     }
 
     /// <summary>

--- a/Content.Shared/_Box/Weapons/Ranged/Upgrades/UpgradeableGunRefreshFireRateEvent.cs
+++ b/Content.Shared/_Box/Weapons/Ranged/Upgrades/UpgradeableGunRefreshFireRateEvent.cs
@@ -1,9 +1,0 @@
-using Content.Shared.Weapons.Ranged.Upgrades.Components;
-
-namespace Content.Shared._Box.Weapons.Ranged.Upgrades;
-
-/// <summary>
-/// Raised when an upgraded gun is upgraded with a fire rate buff
-/// </summary>
-[ByRefEvent]
-public record struct UpgradeableGunRefreshFireRateEvent(float Coefficient);

--- a/Content.Shared/_Box/Weapons/Ranged/Upgrades/UpgradeableGunRefreshFireRateEvent.cs
+++ b/Content.Shared/_Box/Weapons/Ranged/Upgrades/UpgradeableGunRefreshFireRateEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.Weapons.Ranged.Upgrades.Components;
+
+namespace Content.Shared._Box.Weapons.Ranged.Upgrades;
+
+/// <summary>
+/// Raised when an upgraded gun is upgraded with a fire rate buff
+/// </summary>
+[ByRefEvent]
+public record struct UpgradeableGunRefreshFireRateEvent(float Coefficient);

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -63,7 +63,7 @@
     coefficient: 0.22 # Box Change - 1.5 > 0.22 - Modkit Coefficient Rework; Changed from multiplier to flat addition
 # Start harmony change - deltav PKA port
   - type: GunUpgradeCost # DeltaV
-    cost: 25
+    cost: 15 # Box Change - 25 > 15 - range is weakest upgrade
 # End harmony change
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -58,7 +58,7 @@
     #tags: [ GunUpgradeRange ] # DeltaV - allow multiple
     examineText: gun-upgrade-examine-text-range
   - type: GunUpgradeSpeed
-    coefficient: 1.4 # Harmony - 1.5 > 1.4 - Prevents clipping at max stacks
+    coefficient: 0.22 # Box Change - 1.5 > 0.22 - Modkit Coefficient Rework; Changed from multiplier to flat addition
 # Start harmony change - deltav PKA port
   - type: GunUpgradeCost # DeltaV
     cost: 25

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -35,7 +35,7 @@
     #tags: [ GunUpgradeDamage ] # DeltaV - allow multiple
     examineText: gun-upgrade-examine-text-damage
   - type: GunUpgradeDamage
-  # Box Change Start - Modkit Overhaul - moved to coefficient defined in component
+  # Box Change Start - Modkit Overhaul - moved to coefficient defined in component - adds +50% damage per
     # damage:
     #   types:
     #     Blunt: 10
@@ -60,7 +60,7 @@
     #tags: [ GunUpgradeRange ] # DeltaV - allow multiple
     examineText: gun-upgrade-examine-text-range
   - type: GunUpgradeSpeed
-    coefficient: 0.22 # Box Change - 1.5 > 0.22 - Modkit Coefficient Rework; Changed from multiplier to flat addition
+    coefficient: 0.22 # Box Change - 1.5 > 0.22 - Modkit Coefficient Rework; Changed from multiplier to flat addition - 0.22s is +5.5 tiles
 # Start harmony change - deltav PKA port
   - type: GunUpgradeCost # DeltaV
     cost: 15 # Box Change - 25 > 15 - range is weakest upgrade

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -35,10 +35,12 @@
     #tags: [ GunUpgradeDamage ] # DeltaV - allow multiple
     examineText: gun-upgrade-examine-text-damage
   - type: GunUpgradeDamage
-    damage:
-      types:
-        Blunt: 10
-        #Structural: 15 # DeltaV - SS13 parity, 10 blunt per shot only
+  # Box Change Start - Modkit Overhaul - moved to coefficient defined in component
+    # damage:
+    #   types:
+    #     Blunt: 10
+    #     #Structural: 15 # DeltaV - SS13 parity, 10 blunt per shot only
+  # Box Change End
 
 - type: entity
   id: PKAUpgradeRange

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -82,4 +82,4 @@
     #tags: [ GunUpgradeReloadSpeed ] # DeltaV - allow multiple
     examineText: gun-upgrade-examine-text-reload
   - type: GunUpgradeFireRate
-    coefficient: 1.25 # DeltaV - was 1.5, SS13 parity (maths used is different but same result: 0.64s recharge time with 3 upgrades)
+    coefficient: 0.4 # Box Change - 1.5 > 0.4 - Modkit Coefficient Rewrite


### PR DESCRIPTION
## About the PR
Massively overhauls the logic of the PKA modkits, in preperation for expanded modkits

## Why / Balance
Before, all modkits were either exponential (hard to balance), or flat rates (favours specific weapon nieches).

Now, all modkits are linear and percentage based, except range which now always adds 5.5 tiles to PKA range.

The damage modkit has been buffed. Originally it gave a 40% per kit for the PKA with a flat +10 blunt, now it gives a 50% increase per modkit.
This is to balance out the fire rate modkit also having a coefficient of 40%, allowing the damage modkit to remain the better damage improver.

_PKA DPS Numbers_

<img width="696" height="258" alt="image" src="https://github.com/user-attachments/assets/afee89ac-4b7c-4e81-9663-c62bfa942fb9" />


## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
