### PR TITLE
[wizden] Simplify hands UI code 

### DIFF
--- a/Content.Client/UserInterface/Systems/Hands/Controls/HandsContainer.cs
+++ b/Content.Client/UserInterface/Systems/Hands/Controls/HandsContainer.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Client.UserInterface.Systems.Inventory.Controls;
+using Content.Shared.Hands.Components;
 using Robust.Client.UserInterface.Controls;
 
 namespace Content.Client.UserInterface.Systems.Hands.Controls;
@@ -7,10 +9,10 @@ namespace Content.Client.UserInterface.Systems.Hands.Controls;
 public sealed class HandsContainer : ItemSlotUIContainer<HandButton>
 {
     private readonly GridContainer _grid;
-    public int ColumnLimit { get => _grid.Columns; set => _grid.Columns = value; }
-    public int MaxButtonCount { get; set; } = 0;
+    private readonly List<HandButton> _orderedButtons = new();
+    public HandsComponent? PlayerHandsComponent;
 
-    public int MaxButtonsPerRow { get; set;  }= 6;
+    public int ColumnLimit { get; set; } = 6;
 
     /// <summary>
     ///     Indexer. This is used to reference a HandsContainer from the
@@ -24,57 +26,32 @@ public sealed class HandsContainer : ItemSlotUIContainer<HandButton>
         _grid.ExpandBackwards = true;
     }
 
-    public override HandButton? AddButton(HandButton newButton)
+    protected override void AddButton(HandButton newButton)
     {
-        if (MaxButtonCount > 0)
-        {
-            if (ButtonCount >= MaxButtonCount)
-                return null;
+        _orderedButtons.Add(newButton);
 
-            _grid.AddChild(newButton);
-        }
-        else
+        _grid.RemoveAllChildren();
+        var enumerable = PlayerHandsComponent?.SortedHands is { } sortedHands
+            ? _orderedButtons.OrderBy(it => sortedHands.IndexOf(it.SlotName))
+            : _orderedButtons.OrderBy(it => it.HandLocation);
+        foreach (var button in enumerable)
         {
-            _grid.AddChild(newButton);
+            _grid.AddChild(button);
         }
 
-        _grid.Columns = Math.Min(_grid.ChildCount, MaxButtonsPerRow);
-        return base.AddButton(newButton);
+        _grid.Columns = Math.Min(_grid.ChildCount, ColumnLimit);
     }
 
-    public override void RemoveButton(string handName)
+    protected override void RemoveButton(HandButton button)
     {
-        var button = GetButton(handName);
-        if (button == null)
-            return;
-        base.RemoveButton(button);
+        _orderedButtons.Remove(button);
         _grid.RemoveChild(button);
     }
 
-    public bool TryGetLastButton(out HandButton? control)
+    public override void ClearButtons()
     {
-        if (Buttons.Count == 0)
-        {
-            control = null;
-            return false;
-        }
-
-        control = Buttons.Values.Last();
-        return true;
-    }
-
-    public bool TryRemoveLastHand(out HandButton? control)
-    {
-        var success = TryGetLastButton(out control);
-        if (control != null)
-            RemoveButton(control);
-        return success;
-    }
-
-    public void Clear()
-    {
-        ClearButtons();
-        _grid.RemoveAllChildren();
+        base.ClearButtons();
+        _orderedButtons.Clear();
     }
 
     public IEnumerable<HandButton> GetButtons()
@@ -85,8 +62,4 @@ public sealed class HandsContainer : ItemSlotUIContainer<HandButton>
                 yield return hand;
         }
     }
-
-    public bool IsFull => (MaxButtonCount != 0 && ButtonCount >= MaxButtonCount);
-
-    public int ButtonCount => _grid.ChildCount;
 }

--- a/Content.Client/UserInterface/Systems/Hotbar/HotbarUIController.cs
+++ b/Content.Client/UserInterface/Systems/Hotbar/HotbarUIController.cs
@@ -36,7 +36,6 @@ public sealed class HotbarUIController : UIController
         _inventory = UIManager.GetUIController<InventoryUIController>();
         _hands = UIManager.GetUIController<HandsUIController>();
         _storage = UIManager.GetUIController<StorageUIController>();
-        _hands.RegisterHandContainer(handsContainer);
     }
 
     public void ReloadHotbar()

--- a/Content.Client/UserInterface/Systems/Hotbar/Widgets/HotbarGui.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Hotbar/Widgets/HotbarGui.xaml.cs
@@ -11,8 +11,8 @@ public sealed partial class HotbarGui : UIWidget
     public HotbarGui()
     {
         RobustXamlLoader.Load(this);
-        StatusPanelRight.SetSide(HandUILocation.Right);
-        StatusPanelLeft.SetSide(HandUILocation.Left);
+        StatusPanelRight.SetSide(HandLocation.Right);
+        StatusPanelLeft.SetSide(HandLocation.Left);
         var hotbarController = UserInterfaceManager.GetUIController<HotbarUIController>();
 
         hotbarController.Setup(HandContainer);
@@ -29,10 +29,10 @@ public sealed partial class HotbarGui : UIWidget
         StatusPanelRight.Update(entity, hand);
     }
 
-    public void SetHighlightHand(HandUILocation? hand)
+    public void SetHighlightHand(HandLocation? hand)
     {
-        StatusPanelLeft.UpdateHighlight(hand is HandUILocation.Left);
-        StatusPanelRight.UpdateHighlight(hand is HandUILocation.Right);
+        StatusPanelLeft.UpdateHighlight(hand is HandLocation.Left);
+        StatusPanelRight.UpdateHighlight(hand is HandLocation.Right);
     }
 
     public void UpdateStatusVisibility(bool left, bool right)

--- a/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/Controls/ItemStatusPanel.xaml.cs
@@ -20,7 +20,7 @@ public sealed partial class ItemStatusPanel : Control
     [ViewVariables] private Hand? _hand;
 
     // Tracked so we can re-run SetSide() if the theme changes.
-    private HandUILocation _side;
+    private HandLocation _side;
 
     public ItemStatusPanel()
     {
@@ -28,7 +28,7 @@ public sealed partial class ItemStatusPanel : Control
         IoCManager.InjectDependencies(this);
     }
 
-    public void SetSide(HandUILocation location)
+    public void SetSide(HandLocation location)
     {
         // AN IMPORTANT REMINDER ABOUT THIS CODE:
         // In the UI, the RIGHT hand is on the LEFT on the screen.
@@ -43,14 +43,14 @@ public sealed partial class ItemStatusPanel : Control
 
         switch (location)
         {
-            case HandUILocation.Right:
+            case HandLocation.Right or HandLocation.Middle:
                 texture = Theme.ResolveTexture("item_status_right");
                 textureHighlight = Theme.ResolveTexture("item_status_right_highlight");
                 cutOut = StyleBox.Margin.Left;
                 flat = StyleBox.Margin.Right;
                 contentMargin = MarginFromThemeColor("_itemstatus_content_margin_right");
                 break;
-            case HandUILocation.Left:
+            case HandLocation.Left:
                 texture = Theme.ResolveTexture("item_status_left");
                 textureHighlight = Theme.ResolveTexture("item_status_left_highlight");
                 cutOut = StyleBox.Margin.Right;

--- a/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
@@ -147,7 +147,7 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
             if (!container.TryGetButton(data.SlotName, out var button))
             {
                 button = CreateSlotButton(data);
-                container.AddButton(button);
+                container.TryAddButton(button);
             }
 
             var showStorage = _entities.HasComponent<StorageComponent>(data.HeldEntity);
@@ -373,7 +373,7 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
             return;
 
         var button = CreateSlotButton(data);
-        slotGroup.AddButton(button);
+        slotGroup.TryAddButton(button);
     }
 
     private void RemoveSlot(SlotData data)
@@ -381,7 +381,7 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
         if (!_slotGroups.TryGetValue(data.SlotGroup, out var slotGroup))
             return;
 
-        slotGroup.RemoveButton(data.SlotName);
+        slotGroup.TryRemoveButton(data.SlotName, out _);
     }
 
     public void ReloadSlots()

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -169,43 +169,9 @@ public sealed class HandsComponentState : ComponentState
 /// <summary>
 ///     What side of the body this hand is on.
 /// </summary>
-/// <seealso cref="HandUILocation"/>
-/// <seealso cref="HandLocationExt"/>
 public enum HandLocation : byte
 {
-    Left,
+    Right,
     Middle,
-    Right
-}
-
-/// <summary>
-/// What side of the UI a hand is on.
-/// </summary>
-/// <seealso cref="HandLocationExt"/>
-/// <seealso cref="HandLocation"/>
-public enum HandUILocation : byte
-{
-    Left,
-    Right
-}
-
-/// <summary>
-/// Helper functions for working with <see cref="HandLocation"/>.
-/// </summary>
-public static class HandLocationExt
-{
-    /// <summary>
-    /// Convert a <see cref="HandLocation"/> into the appropriate <see cref="HandUILocation"/>.
-    /// This maps "middle" hands to <see cref="HandUILocation.Right"/>.
-    /// </summary>
-    public static HandUILocation GetUILocation(this HandLocation location)
-    {
-        return location switch
-        {
-            HandLocation.Left => HandUILocation.Left,
-            HandLocation.Middle => HandUILocation.Right,
-            HandLocation.Right => HandUILocation.Right,
-            _ => throw new ArgumentOutOfRangeException(nameof(location), location, null)
-        };
-    }
+    Left
 }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -90,6 +90,8 @@ public abstract partial class SharedHandsSystem
 
         ent.Comp.Hands.Add(handName, hand);
         ent.Comp.SortedHands.Add(handName);
+        // we use LINQ + ToList instead of the list sort because it's a stable sort vs the list sort
+        ent.Comp.SortedHands = ent.Comp.SortedHands.OrderBy(handId => ent.Comp.Hands[handId].Location).ToList();
         Dirty(ent);
 
         OnPlayerAddHand?.Invoke((ent, ent.Comp), handName, hand.Location);


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
cherry-picks space-wizards/space-station-14/pull/42534
fixes avali hands and hopefully hands sometimes being fucked up after dying
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
broken
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
avali with normal hands
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="564" height="587" alt="image" src="https://github.com/user-attachments/assets/2012dd14-fc80-4de5-8292-18d22c50afe8" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Hands will no longer sometimes display in the wrong order.
