### PR TITLE
[harmony] Fixed missing state fields for Avali headwear displacements

### DIFF
--- a/Resources/Prototypes/_CD/Body/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Body/Species/avali.yml
@@ -63,19 +63,23 @@
         sizeMaps:
           32:
             sprite: _Harmony/Mobs/Species/Avali/displacement.rsi
+            state: head
       mask:
         sizeMaps:
           32:
             sprite: _Harmony/Mobs/Species/Avali/displacement.rsi
+            state: mask
     displacements:
       head:
         sizeMaps:
           32:
             sprite: _Harmony/Mobs/Species/Avali/displacement.rsi
+            state: head
       mask:
         sizeMaps:
           32:
             sprite: _Harmony/Mobs/Species/Avali/displacement.rsi
+            state: mask
   - type: InitialBody
     organs:
       Torso: OrganAvaliTorso


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
cherry-picks ss14-harmony/ss14-harmony/pull/1300
should hopefully fix horrible awful fucked up avali sprite glitches
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
whatever the fuck this is
<img width="295" height="323" alt="SS14 Loader_LsRH11UA9Q" src="https://github.com/user-attachments/assets/3e041d25-3bc6-4930-9059-84bcec498928" />
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
avali wearing a hat without breaking the fabric of reality
<img width="393" height="440" alt="image" src="https://github.com/user-attachments/assets/fccc575e-abeb-417e-b263-cccbe0a6420f" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Headwear no longer uses the incorrect sprite when worn by avali.
