### PR TITLE
minor tweaks to the harpy singer system

### DIFF
--- a/Content.Server/_DV/Harpy/HarpySingerSystem.cs
+++ b/Content.Server/_DV/Harpy/HarpySingerSystem.cs
@@ -19,7 +19,7 @@ using Content.Shared.UserInterface;
 using Content.Shared.Zombies;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-// Start Box Change: Additions for sspeech/emote checks
+// Start Box Change: Additions for speech/emote checks
 using Content.Shared.Speech.Muting;
 using Content.Shared.Abilities.Mime;
 // End Box Change

--- a/Content.Server/_DV/Harpy/HarpySingerSystem.cs
+++ b/Content.Server/_DV/Harpy/HarpySingerSystem.cs
@@ -19,6 +19,10 @@ using Content.Shared.UserInterface;
 using Content.Shared.Zombies;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+// Start Box Change: Additions for sspeech/emote checks
+using Content.Shared.Speech.Muting;
+using Content.Shared.Abilities.Mime;
+// End Box Change
 
 namespace Content.Server._DV.Harpy;
 
@@ -37,7 +41,7 @@ public sealed class HarpySingerSystem : SharedHarpySingerSystem
         SubscribeLocalEvent<InstrumentComponent, MobStateChangedEvent>(OnMobStateChangedEvent);
         SubscribeLocalEvent<GotEquippedEvent>(OnEquip);
         SubscribeLocalEvent<EntityZombifiedEvent>(OnZombified);
-        SubscribeLocalEvent<InstrumentComponent, KnockedDownEvent>(OnKnockedDown);
+        //SubscribeLocalEvent<InstrumentComponent, KnockedDownEvent>(OnKnockedDown); // Box Change: Disabled, see below
         SubscribeLocalEvent<InstrumentComponent, StunnedEvent>(OnStunned);
         SubscribeLocalEvent<InstrumentComponent, SleepStateChangedEvent>(OnSleep);
         SubscribeLocalEvent<InstrumentComponent, StatusEffectAddedEvent>(OnStatusEffect);
@@ -71,10 +75,13 @@ public sealed class HarpySingerSystem : SharedHarpySingerSystem
         CloseMidiUi(args.Target);
     }
 
-    private void OnKnockedDown(EntityUid uid, InstrumentComponent component, ref KnockedDownEvent args)
-    {
-        CloseMidiUi(uid);
-    }
+    // Box Change: Almost every instance of forced knockdown also comes with stun. All this really does is cause harpies to close their MIDI interface when voluntarily going prone.
+    // The only exception I can even find (something that knocks you down without stunning you) is slipping into the bingle pit.
+    //private void OnKnockedDown(EntityUid uid, InstrumentComponent component, ref KnockedDownEvent args)
+    //{
+    //    CloseMidiUi(uid);
+    //}
+    // End Box Change
 
     private void OnStunned(EntityUid uid, InstrumentComponent component, ref StunnedEvent args)
     {
@@ -134,6 +141,8 @@ public sealed class HarpySingerSystem : SharedHarpySingerSystem
         }
     }
 
+    // Box TODO: As it stands, this cancels the UI openinng in a kinda scuffed way that leaves the singing visuals stuck on your character permanently.
+    //           We should probably find a way to remove the action completely instead.
     /// <summary>
     /// Prevent the player from opening the MIDI UI under some circumstances.
     /// </summary>
@@ -141,7 +150,10 @@ public sealed class HarpySingerSystem : SharedHarpySingerSystem
     {
         // CanSpeak covers all reasons you can't talk, including being incapacitated
         // (crit/dead), asleep, or for any reason mute inclding glimmer or a mime's vow.
-        var canNotSpeak = !_blocker.CanSpeak(uid);
+        // Start Box Change: Check for Muted/MimePowers components instead of speech blocker. Cover other instances with CanEmote instead.
+        var canNotSpeak = HasComp<MutedComponent>(uid) || HasComp<MimePowersComponent>(uid);
+        var canNotEmote = !_blocker.CanEmote(uid);
+        // End Box Change
         var zombified = TryComp<ZombieComponent>(uid, out var _);
         var muzzled = _inventorySystem.TryGetSlotEntity(uid, "mask", out var maskUid) &&
             TryComp<AddAccentClothingComponent>(maskUid, out var accent) &&
@@ -149,7 +161,7 @@ public sealed class HarpySingerSystem : SharedHarpySingerSystem
 
         // Set this event as handled when the singer should be incapable of singing in order
         // to stop the ActivatableUISystem event from opening the MIDI UI.
-        args.Handled = canNotSpeak || muzzled || zombified;
+        args.Handled = canNotSpeak || muzzled || zombified || canNotEmote; // Box Change: Add canNotEmote
 
         // Tell the user that they can not sing.
         if (args.Handled)

--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -70,9 +70,14 @@
       state: body-overlay-2
       visible: false
 
-    # Delta V - Harpy Wings
+    # Start Box Change: Harpy stuff
     - map: [ "enum.HumanoidVisualLayers.RArmExtension" ]
     - map: [ "enum.HumanoidVisualLayers.LArmExtension" ]
+    - map: [ enum.InstrumentVisuals.Layer ]
+      sprite: _DV/Effects/harpysinger.rsi
+      state: singing_music_notes
+      visible: false
+    # End Box Change
 
 - type: entity
   id: BaseSpeciesAppearance

--- a/Resources/Prototypes/Body/species_appearance.yml
+++ b/Resources/Prototypes/Body/species_appearance.yml
@@ -70,14 +70,9 @@
       state: body-overlay-2
       visible: false
 
-    # Start Box Change: Harpy stuff
+    # Delta V - Harpy Wings
     - map: [ "enum.HumanoidVisualLayers.RArmExtension" ]
     - map: [ "enum.HumanoidVisualLayers.LArmExtension" ]
-    - map: [ enum.InstrumentVisuals.Layer ]
-      sprite: _DV/Effects/harpysinger.rsi
-      state: singing_music_notes
-      visible: false
-    # End Box Change
 
 - type: entity
   id: BaseSpeciesAppearance


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
- no longer close the midi ui when harpies are knocked down (in practice almost every instance of knockdown comes with a stun, which the system already covers. the only stunless knockdowns i've been able to find are slipping into the bingle pit, and manually going prone (which is a way bigger deal than letting a harpy continue to sing as they fall into The Hole))
- add a slight bit more nuance to the midi-interface-opening logic. previously any character that could not speak was incapable of opening the interface, now it checks for the muted and mime components specifically. this should allow harpies with a theoretical nonverbal trait (blocks speech but does not mute emotes; something i have planned to add) to still sing.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it's annoying to have your song cut off because you manually went prone
nonverbal harpies should be able to sing
## Technical details
<!-- Summary of code changes for easier review. -->
removed the event subscription for knockdown
canNotSpeak no longer checks for speechblocker, but instead for the muted and mimepowers components specifically
canNotEmote has been added to cover the other instances that canNotSpeak previously did
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Harpies will no longer stop singing when manually going prone.
