### PR TITLE
cleanup: remove spacepresso flatpack, remove mining winter jacket from cargodrobe

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -20,7 +20,6 @@
     - id: DrinkBeerBottleFull
       amount: !type:BinomialNumberSelector
         trials: 3
-    - id: SpacepressoFlatpack # Box Change: Spacepresso flatpack for bartender. TODO: Map these and remove the flatpack.
     - !type:AllSelector
       rolls: 2
       children:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cargodrobe.yml
@@ -18,7 +18,7 @@
     ClothingHeadBandBrown: 3
     ClothingHeadsetCargo: 3
     ClothingOuterWinterCargo: 2
-    ClothingOuterWinterMiner: 2 # TODO: Remove this once we've mapped SalvDrobes everywhere
+    #ClothingOuterWinterMiner: 2 # Box Change: Removed (moved to SalvDrobe)
     ClothingOuterCoatBomberCargo: 2 #Box - Adds Imp Bomber Jackets
     ClothingNeckScarfStripedBrown: 3
     ClothingShoesBootsWinterCargo: 2

--- a/Resources/Prototypes/_Box/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Box/Entities/Objects/Devices/flatpack.yml
@@ -11,18 +11,3 @@
     sprite: _Box/Objects/Devices/flatpack.rsi
     layers:
     - state: borgcharger
-
-- type: entity
-  parent: BaseFlatpack
-  id: SpacepressoFlatpack
-  name: spacepresso flatpack
-  description: A flatpack used for constructing a spacepresso machine.
-  components:
-  - type: Flatpack
-    entity: ImpCoffeeMachine
-  - type: Sprite
-    layers:
-    - state: base
-    - state: overlay
-      color: "#9FED58"
-    - state: icon-default


### PR DESCRIPTION
<!-- If you are new to the BoxStation repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md). We follow Harmony guidelines, so please keep your comments tidy! -->
## About the PR
<!-- What did you change? -->
removed the spacepresso flatpack prototype, and removed it from the bartender's locker
removed the mining winter jacket from the cargodrobe
needs #270 for these mapping updates to be finalized
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
spacepresso flatpack only existed as a placeholder until we mapped them (which we have now)
mining winter jacket remained to keep it accessible until we mapped salvdrobes (which we have now)
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: The bartender's locker no longer contains a spacepresso flatpack (a spacepresso machine is now mapped on every map in rotation).
- remove: The CargoDrobe no longer stocks the mining winter coat (they can now be found in the SalvDrobe, instead).