### PR TITLE
[PORT] Imp Deathmatch Fixes

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
@@ -43,4 +43,12 @@ public sealed partial class DeathMatchRuleComponent : Component
     /// </summary>
     [DataField("gear", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>)), ViewVariables(VVAccess.ReadWrite)]
     public string Gear = "DeathMatchGear";
+    /// Box Change Start - Imp - death on crit
+    /// <summary>
+    /// If true, lowers players' entities death thresholds to their critical thresholds because waiting to press
+    /// the succumb button sucks when you want to kill people. Imp addition.
+    /// </summary>
+    [DataField]
+    public bool InstantDeath = true;
+    /// Box Change End - Imp - death on crit
 }

--- a/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
@@ -13,6 +13,8 @@ using Content.Shared.Storage;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Utility;
+using Content.Shared.Mobs; // Box - Imp - Deathmatch Death on Crit
+using Content.Shared.Mobs.Systems;  // Box - Imp - Deathmatch Death on Crit
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -29,6 +31,8 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;
     [Dependency] private readonly StationSpawningSystem _stationSpawning = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!; // Box - Imp - Deathmatch Death on Crit
+
 
     public override void Initialize()
     {
@@ -54,6 +58,10 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
             var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(ev.Station, null, ev.Profile);
             DebugTools.AssertNotNull(mobMaybe);
             var mob = mobMaybe!.Value;
+            // Box - imp edit start, set the death threshold to the critical threshold
+            if (dm.InstantDeath)
+                _mobThresholdSystem.SetMobStateThreshold(mob, _mobThresholdSystem.GetThresholdForState(mob, MobState.Critical), MobState.Dead);
+            //Box - imp edit end
 
             _mind.TransferTo(newMind, mob);
             _outfitSystem.SetOutfit(mob, dm.Gear);
@@ -61,7 +69,13 @@ public sealed class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRuleComponen
             _respawn.AddToTracker(ev.Player.UserId, (uid, tracker));
 
             _point.EnsurePlayer(ev.Player.UserId, uid, point);
-
+            //Box - imp edit start, make the Dead state count as the kill state instead of Critical, for instant deathmatch death
+            if (dm.InstantDeath)
+            {
+                if (TryComp<KillTrackerComponent>(mob, out var killTrackerComponent))
+                    killTrackerComponent.KillState = MobState.Dead;
+            }
+            //Box - imp edit end
             ev.Handled = true;
             break;
         }

--- a/Content.Server/KillTracking/KillTrackerComponent.cs
+++ b/Content.Server/KillTracking/KillTrackerComponent.cs
@@ -1,13 +1,15 @@
 ﻿using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Robust.Shared.Network;
-
+using Content.Server.GameTicking.Rules; // Box - imp - Deathmatch Death on Crit
 namespace Content.Server.KillTracking;
 
 /// <summary>
 /// This is used for entities that track player damage sources and killers.
 /// </summary>
-[RegisterComponent, Access(typeof(KillTrackingSystem))]
+
+/// [RegisterComponent, Access(typeof(KillTrackingSystem))] // Box Change - Comments out to replace for Death on Crit system
+[RegisterComponent, Access(typeof(KillTrackingSystem), typeof(DeathMatchRuleSystem))] //Box - imp edit, add ", typeof(DeathMatchRuleSystem)"
 public sealed partial class KillTrackerComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
## About the PR
ports https://github.com/impstation/imp-station-14/pull/4317

Makes it so when someone would go into crit in deathmatch, they are instead set to dead and able to ghost.
This fixes multiple issues:
-allows IPCs to exist in deathmatch without being an issue due to their lack of crit state
-players dont need to /ghost out to respawn faster, risking their body sans mind going from crit to alive and locking them out of respawning.

## Why / Balance
QOL fixes and makes IPCs playable.

## Technical details
-edits to Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
-edits to Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
-Content.Server/KillTracking/KillTrackerComponent.cs

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- tweak: In deathmatch, instead of going into a critical state you will now instantly die.
- tweak: In deathmatch, points are now tallied on death and not on entering crit.

